### PR TITLE
feat: use learner portal hostname config variable

### DIFF
--- a/src/enterprise/getLearnerPortalLinks.js
+++ b/src/enterprise/getLearnerPortalLinks.js
@@ -20,6 +20,9 @@ const fetchLearnerPortalLinks = async (userId) => {
   const httpClient = getAuthenticatedHttpClient();
   const enterpriseApiUrl = `${getConfig().LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/`;
   const enterpriseLearnerPortalHostname = process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME;
+  if (!enterpriseLearnerPortalHostname) {
+    return [];
+  }
 
   try {
     const { data } = await httpClient.get(enterpriseApiUrl);

--- a/src/enterprise/getLearnerPortalLinks.js
+++ b/src/enterprise/getLearnerPortalLinks.js
@@ -19,7 +19,7 @@ const cacheLinks = (userId, links) => {
 const fetchLearnerPortalLinks = async (userId) => {
   const httpClient = getAuthenticatedHttpClient();
   const enterpriseApiUrl = `${getConfig().LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/`;
-  const enterpriseLearnerPortalHostname = process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME
+  const enterpriseLearnerPortalHostname = process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME;
 
   try {
     const { data } = await httpClient.get(enterpriseApiUrl);

--- a/src/enterprise/getLearnerPortalLinks.js
+++ b/src/enterprise/getLearnerPortalLinks.js
@@ -19,20 +19,21 @@ const cacheLinks = (userId, links) => {
 const fetchLearnerPortalLinks = async (userId) => {
   const httpClient = getAuthenticatedHttpClient();
   const enterpriseApiUrl = `${getConfig().LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/`;
+  const enterpriseLearnerPortalHostname = process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME
 
   try {
     const { data } = await httpClient.get(enterpriseApiUrl);
     const enterpriseCustomers = data.results.map(customer => ({
       name: customer.name,
       isEnabled: customer.enable_learner_portal,
-      hostname: customer.learner_portal_hostname,
+      slug: customer.slug,
     }));
 
     const links = enterpriseCustomers
-      .filter(({ isEnabled, hostname }) => isEnabled && hostname)
-      .map(({ name, hostname }) => ({
+      .filter(({ isEnabled, slug }) => isEnabled && slug)
+      .map(({ name, slug }) => ({
         title: name,
-        url: `https://${hostname}`,
+        url: `https://${enterpriseLearnerPortalHostname}/${slug}`,
       }));
 
     cacheLinks(userId, links);


### PR DESCRIPTION
BREAKING CHANGE: requires the presence of ENTERPRISE_LEARNER_PORTAL_HOSTNAME env var to properly generate learner portal urls