### PR TITLE
fix: upgrade frontend-enterprise to 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,9 +1347,29 @@
       }
     },
     "@edx/frontend-enterprise": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-4.1.3.tgz",
-      "integrity": "sha512-3VFCO53hOEYehbmqh3LeWRsE05lcFOeluD6t1e69QnCN+7sOJo111cpJ3UcUirBWb93guvK2Xe6g0kmqcMw/pw=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-4.2.3.tgz",
+      "integrity": "sha512-znqnP/PVCemhZS0rSwjt+tjrXSPfJqnQ2YHnXlb9O9wJ/JDHIoYs3Nsd0Auo2tuwhtffTQyFwPphoEKEPtJjiw==",
+      "requires": {
+        "query-string": "^6.13.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "6.13.2",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
+          "integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
+      }
     },
     "@edx/frontend-platform": {
       "version": "1.1.14",
@@ -5440,8 +5460,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress": {
       "version": "4.2.1",
@@ -16695,6 +16714,11 @@
           }
         }
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "redux-saga": "1.1.3"
   },
   "dependencies": {
-    "@edx/frontend-enterprise": "^4.1.3",
+    "@edx/frontend-enterprise": "^4.2.3",
     "babel-polyfill": "^6.26.0",
     "react-responsive": "8.0.3",
     "react-transition-group": "4.3.0"


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-3390

Upgraded frontend-enterprise release: https://github.com/edx/frontend-enterprise/releases/tag/v4.2.3

This fixes an issue for internal/staff users - we now only fetch your preferred enterprise and use that to make a determination about whether or not to show Order History. Previously, we fetched every enterprise the user is associated with, which for staff users, can be many.