### PR TITLE
[REV-2070] feat: update desktop and mobile header to use avatar button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.0.5.tgz",
-      "integrity": "sha512-5DhpXa1DktxOX2t7hdVBMYTWr0gn/30JKBq/ohjpCrnAbMfo6fM9MZkVlAtYKPmLOecxebL5ATTAKeP/T+WP3w==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.6.1.tgz",
+      "integrity": "sha512-YOwKWEwMch3Ris59Qz4um9TyHmcR52i6TxAWJzFi0FWQ/I8cKcwREboM8suseFoLn+3l3bpuI6fEjq9ECwZkuQ==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
@@ -2624,9 +2624,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.4.tgz",
-      "integrity": "sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==",
       "dev": true
     },
     "@redux-saga/core": {
@@ -2689,13 +2689,13 @@
       "dev": true
     },
     "@restart/hooks": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.25.tgz",
-      "integrity": "sha512-m2v3N5pxTsIiSH74/sb1yW8D9RxkJidGW+5Mfwn/lHb2QzhZNlaU1su7abSyT9EGf0xS/0waLjrf7/XxQHUk7w==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
+      "integrity": "sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -3144,9 +3144,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-jJjHo1uOe+NENRIBvF46tJimUvPnmbQ41Ax0pEm7pRvhPg+wuj8VMOHHiMvaGmZRzRrCtm7KnL5OOE/6kHPK8w==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -13250,9 +13250,9 @@
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
+      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -16440,9 +16440,9 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.4.0.tgz",
-      "integrity": "sha512-0BMzgeUAxH126v7VYDzIXbHxQVHSnniPVKpz9fblumdQpWaiElMnnzk+u8h8DoELX0nCXwPlcUzgXqmpncdc2Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.4.3.tgz",
+      "integrity": "sha512-4tYhk26KRnK0myMEp2wvNjOvnHMwWfa6pWFIiCtj9wewYaTxP7TrCf7MwcIMBgUzyX0SJXx6UbbDG0+hObiXNg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.2",
@@ -16451,7 +16451,7 @@
         "@types/classnames": "^2.2.10",
         "@types/invariant": "^2.2.33",
         "@types/prop-types": "^15.7.3",
-        "@types/react": "^16.9.35",
+        "@types/react": ">=16.9.35",
         "@types/react-transition-group": "^4.4.0",
         "@types/warning": "^3.0.0",
         "classnames": "^2.2.6",
@@ -16480,9 +16480,9 @@
       }
     },
     "react-clientside-effect": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
-      "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.3.tgz",
+      "integrity": "sha512-96HOmjJjjemxZD4qMdaMWFl3d/3Dqm/MAXnThoP8+jQihevYs8VzooqYWlVEPmkp9tVIa06i67R7FF1qsuzUwQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0"
@@ -16836,9 +16836,9 @@
       }
     },
     "react-focus-on": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.0.tgz",
-      "integrity": "sha512-RqGAHOxhRAaMSVHIN5IpY7YL6AJkD/DMa/+iPDV7aB6XWRQfg3v2q35egIZgMWP2xhXaRVai3B80dpVWyj4Rcw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.1.tgz",
+      "integrity": "sha512-6iE56nYNwVU6Pke362TjqRLz/G7DBGnEugkxhPAhpXEZW5og3vhc9qDPlyiHgxoiY9kYTWjdAEFz4nJgSluANg==",
       "dev": true,
       "requires": {
         "aria-hidden": "^1.1.1",
@@ -16959,9 +16959,9 @@
       }
     },
     "react-remove-scroll": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.0.tgz",
-      "integrity": "sha512-BZIO3GaEs0Or1OhA5C//n1ibUP1HdjJmqUVUsOCMxwoIpaCocbB9TFKwHOkBa/nyYy3slirqXeiPYGwdSDiseA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz",
+      "integrity": "sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==",
       "dev": true,
       "requires": {
         "react-remove-scroll-bar": "^2.1.0",
@@ -16980,9 +16980,9 @@
       }
     },
     "react-remove-scroll-bar": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.0.tgz",
-      "integrity": "sha512-5X5Y5YIPjIPrAoMJxf6Pfa7RLNGCgwZ95TdnVPgPuMftRfO8DaC7F4KP1b5eiO8hHbe7u+wZNDbYN5WUTpv7+g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.1.tgz",
+      "integrity": "sha512-IZbfQPSozIr8ylHE9MFcQeb2TTzj4abfE7OBXjmtUeXQ5h6ColGKDNo5h7OmzrJRilAx3YIKBf3jb0yrb31BJQ==",
       "dev": true,
       "requires": {
         "react-style-singleton": "^2.1.0",
@@ -17059,9 +17059,9 @@
       }
     },
     "react-style-singleton": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.0.tgz",
-      "integrity": "sha512-DH4ED+YABC1dhvSDYGGreAHmfuTXj6+ezT3CmHoqIEfxNgEYfIMoOtmbRp42JsUst3IPqBTDL+8r4TF7EWhIHw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
       "dev": true,
       "requires": {
         "get-nonce": "^1.0.0",
@@ -17930,20 +17930,31 @@
       },
       "dependencies": {
         "dom-serializer": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
-          "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+          "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
           "dev": true,
           "requires": {
             "domelementtype": "^2.0.1",
-            "domhandler": "^3.0.0",
+            "domhandler": "^4.0.0",
             "entities": "^2.0.0"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+              "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+              "dev": true,
+              "requires": {
+                "domelementtype": "^2.1.0"
+              }
+            }
           }
         },
         "domelementtype": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
           "dev": true
         },
         "domhandler": {
@@ -17956,14 +17967,25 @@
           }
         },
         "domutils": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
-          "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+          "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
             "domelementtype": "^2.0.1",
-            "domhandler": "^3.3.0"
+            "domhandler": "^4.0.0"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+              "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+              "dev": true,
+              "requires": {
+                "domelementtype": "^2.1.0"
+              }
+            }
           }
         },
         "htmlparser2": {
@@ -19945,6 +19967,18 @@
         "@types/react": "^16.9.11",
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.14.2",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+          "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
+          }
+        }
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@edx/brand": "npm:@edx/brand-edx.org@1.2.5",
     "@edx/frontend-build": "5.4.0",
     "@edx/frontend-platform": "1.8.0",
-    "@edx/paragon": "12.0.5",
+    "@edx/paragon": "12.6.1",
     "codecov": "3.7.2",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.14.0",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^1.8.0",
-    "@edx/paragon": "^7.0.0",
+    "@edx/paragon": "^12.4.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 // Local Components
+import { AvatarButton, Dropdown } from '@edx/paragon';
 import { Menu, MenuTrigger, MenuContent } from './Menu';
-import Avatar from './Avatar';
 import { LinkedLogo, Logo } from './Logo';
 
 // i18n
@@ -62,22 +62,25 @@ class DesktopHeader extends React.Component {
     } = this.props;
 
     return (
-      <Menu transitionClassName="menu-dropdown" transitionTimeout={250}>
-        <MenuTrigger
-          data-hj-suppress
-          tag="button"
+      <Dropdown>
+        <Dropdown.Toggle
+          as={AvatarButton}
+          src={avatar}
+          alt=""
           aria-label={intl.formatMessage(messages['header.label.account.menu.for'], { username })}
-          className="btn btn-outline-primary d-inline-flex align-items-center pl-2 pr-3"
+          data-hj-suppress
         >
-          <Avatar size="1.5em" src={avatar} alt="" className="mr-2" />
-          {username} <CaretIcon role="img" aria-hidden focusable="false" />
-        </MenuTrigger>
-        <MenuContent className="mb-0 dropdown-menu show dropdown-menu-right pin-right shadow py-2">
+          {username}
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu alignRight>
           {userMenu.map(({ type, href, content }) => (
-            <a className={`dropdown-${type}`} key={`${type}-${content}`} href={href}>{content}</a>
+            <Dropdown.Item key={`${type}-${content}`} href={href}>
+              {content}
+            </Dropdown.Item>
           ))}
-        </MenuContent>
-      </Menu>
+        </Dropdown.Menu>
+      </Dropdown>
     );
   }
 

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -117,9 +117,10 @@ describe('<Header />', () => {
     const flushPromises = () => new Promise(setImmediate);
     await act(async () => {
       await flushPromises();
+      wrapper.update();
+      wrapper.find('DropdownToggle').simulate('click');
     });
-    wrapper.update();
-    wrapper.find('.menu-trigger').simulate('click');
+
     expect(wrapper.find('a[children="Order History"]')).toHaveLength(1);
     expect(wrapper.find('a[children="Dashboard"]')).toHaveLength(1);
 
@@ -131,9 +132,9 @@ describe('<Header />', () => {
     wrapper = mount(component);
     await act(async () => {
       await flushPromises();
+      wrapper.update();
+      wrapper.find('DropdownToggle').simulate('click');
     });
-    wrapper.update();
-    wrapper.find('.menu-trigger').simulate('click');
     expect(wrapper.find('a[children="Order History"]')).toHaveLength(0);
     expect(wrapper.find('a[children="Dashboard"]')).toHaveLength(1);
   });

--- a/src/Menu/Menu.jsx
+++ b/src/Menu/Menu.jsx
@@ -9,7 +9,7 @@ function MenuTrigger({ tag, className, ...attributes }) {
   });
 }
 MenuTrigger.propTypes = {
-  tag: PropTypes.string,
+  tag: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   className: PropTypes.string,
 };
 MenuTrigger.defaultProps = {

--- a/src/MobileHeader.jsx
+++ b/src/MobileHeader.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 // Local Components
+import { AvatarButton } from '@edx/paragon';
 import { Menu, MenuTrigger, MenuContent } from './Menu';
-import Avatar from './Avatar';
 import { LinkedLogo, Logo } from './Logo';
 
 // i18n
@@ -130,12 +130,13 @@ class MobileHeader extends React.Component {
           {userMenu.length > 0 || loggedOutItems.length > 0 ? (
             <Menu tag="nav" aria-label={intl.formatMessage(messages['header.label.secondary.nav'])} className="position-static">
               <MenuTrigger
-                tag="button"
-                className="icon-button"
+                tag={AvatarButton}
                 aria-label={intl.formatMessage(messages['header.label.account.menu'])}
                 title={intl.formatMessage(messages['header.label.account.menu'])}
+                src={avatar}
+                showLabel={false}
               >
-                <Avatar size="1.5rem" src={avatar} alt={username} />
+                {username}
               </MenuTrigger>
               <MenuContent tag="ul" className="nav flex-column pin-left pin-right border-top shadow py-2">
                 {loggedIn ? this.renderUserMenuItems() : this.renderLoggedOutItems()}

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -24,66 +24,30 @@ exports[`<Header /> minimal renders correctly for authenticated users when minim
         className="nav secondary-menu-container align-items-center ml-auto"
       >
         <div
-          className="menu null"
+          className="dropdown"
           onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
         >
           <button
+            alt=""
             aria-expanded={false}
-            aria-haspopup="menu"
+            aria-haspopup={true}
             aria-label="Account menu for edX"
-            className="menu-trigger btn btn-outline-primary d-inline-flex align-items-center pl-2 pr-3"
+            className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
             data-hj-suppress={true}
+            disabled={false}
             onClick={[Function]}
+            type="button"
           >
             <span
-              className="avatar overflow-hidden d-inline-flex rounded-circle mr-2"
-              style={
-                Object {
-                  "height": "1.5em",
-                  "width": "1.5em",
-                }
-              }
+              className="pgn__avatar-button-avatar-wrap"
             >
-              <svg
-                aria-hidden={true}
-                focusable="false"
-                height="24px"
-                role="img"
-                style={
-                  Object {
-                    "height": "1.5em",
-                    "width": "1.5em",
-                  }
-                }
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M4.10255106,18.1351061 C4.7170266,16.0581859 8.01891846,14.4720277 12,14.4720277 C15.9810815,14.4720277 19.2829734,16.0581859 19.8974489,18.1351061 C21.215206,16.4412566 22,14.3122775 22,12 C22,6.4771525 17.5228475,2 12,2 C6.4771525,2 2,6.4771525 2,12 C2,14.3122775 2.78479405,16.4412566 4.10255106,18.1351061 Z M12,24 C5.372583,24 0,18.627417 0,12 C0,5.372583 5.372583,0 12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 Z M12,13 C9.790861,13 8,11.209139 8,9 C8,6.790861 9.790861,5 12,5 C14.209139,5 16,6.790861 16,9 C16,11.209139 14.209139,13 12,13 Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <img
+                alt=""
+                className="pgn__avatar pgn__avatar-sm"
+                src="icon/mock/path"
+              />
             </span>
             edX
-             
-            <svg
-              aria-hidden={true}
-              focusable="false"
-              height="16px"
-              role="img"
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="16px"
-            >
-              <path
-                d="M7,4 L7,8 L11,8 L11,10 L5,10 L5,4 L7,4 Z"
-                fill="currentColor"
-                transform="translate(8.000000, 7.000000) rotate(-45.000000) translate(-8.000000, -7.000000) "
-              />
-            </svg>
           </button>
         </div>
       </nav>
@@ -181,66 +145,30 @@ exports[`<Header /> renders correctly for authenticated users on desktop 1`] = `
         className="nav secondary-menu-container align-items-center ml-auto"
       >
         <div
-          className="menu null"
+          className="dropdown"
           onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
         >
           <button
+            alt=""
             aria-expanded={false}
-            aria-haspopup="menu"
+            aria-haspopup={true}
             aria-label="Account menu for edX"
-            className="menu-trigger btn btn-outline-primary d-inline-flex align-items-center pl-2 pr-3"
+            className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
             data-hj-suppress={true}
+            disabled={false}
             onClick={[Function]}
+            type="button"
           >
             <span
-              className="avatar overflow-hidden d-inline-flex rounded-circle mr-2"
-              style={
-                Object {
-                  "height": "1.5em",
-                  "width": "1.5em",
-                }
-              }
+              className="pgn__avatar-button-avatar-wrap"
             >
-              <svg
-                aria-hidden={true}
-                focusable="false"
-                height="24px"
-                role="img"
-                style={
-                  Object {
-                    "height": "1.5em",
-                    "width": "1.5em",
-                  }
-                }
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M4.10255106,18.1351061 C4.7170266,16.0581859 8.01891846,14.4720277 12,14.4720277 C15.9810815,14.4720277 19.2829734,16.0581859 19.8974489,18.1351061 C21.215206,16.4412566 22,14.3122775 22,12 C22,6.4771525 17.5228475,2 12,2 C6.4771525,2 2,6.4771525 2,12 C2,14.3122775 2.78479405,16.4412566 4.10255106,18.1351061 Z M12,24 C5.372583,24 0,18.627417 0,12 C0,5.372583 5.372583,0 12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 Z M12,13 C9.790861,13 8,11.209139 8,9 C8,6.790861 9.790861,5 12,5 C14.209139,5 16,6.790861 16,9 C16,11.209139 14.209139,13 12,13 Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <img
+                alt=""
+                className="pgn__avatar pgn__avatar-sm"
+                src="icon/mock/path"
+              />
             </span>
             edX
-             
-            <svg
-              aria-hidden={true}
-              focusable="false"
-              height="16px"
-              role="img"
-              version="1.1"
-              viewBox="0 0 16 16"
-              width="16px"
-            >
-              <path
-                d="M7,4 L7,8 L11,8 L11,10 L5,10 L5,4 L7,4 Z"
-                fill="currentColor"
-                transform="translate(8.000000, 7.000000) rotate(-45.000000) translate(-8.000000, -7.000000) "
-              />
-            </svg>
           </button>
         </div>
       </nav>
@@ -340,39 +268,20 @@ exports[`<Header /> renders correctly for authenticated users on mobile 1`] = `
         aria-expanded={false}
         aria-haspopup="menu"
         aria-label="Account Menu"
-        className="menu-trigger icon-button"
+        className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md menu-trigger null pgn__avatar-button-hide-label btn btn-tertiary btn-md"
+        disabled={false}
         onClick={[Function]}
         title="Account Menu"
+        type="button"
       >
         <span
-          className="avatar overflow-hidden d-inline-flex rounded-circle null"
-          style={
-            Object {
-              "height": "1.5rem",
-              "width": "1.5rem",
-            }
-          }
+          className="pgn__avatar-button-avatar-wrap"
         >
-          <svg
-            aria-hidden={true}
-            focusable="false"
-            height="24px"
-            role="img"
-            style={
-              Object {
-                "height": "1.5rem",
-                "width": "1.5rem",
-              }
-            }
-            version="1.1"
-            viewBox="0 0 24 24"
-            width="24px"
-          >
-            <path
-              d="M4.10255106,18.1351061 C4.7170266,16.0581859 8.01891846,14.4720277 12,14.4720277 C15.9810815,14.4720277 19.2829734,16.0581859 19.8974489,18.1351061 C21.215206,16.4412566 22,14.3122775 22,12 C22,6.4771525 17.5228475,2 12,2 C6.4771525,2 2,6.4771525 2,12 C2,14.3122775 2.78479405,16.4412566 4.10255106,18.1351061 Z M12,24 C5.372583,24 0,18.627417 0,12 C0,5.372583 5.372583,0 12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 Z M12,13 C9.790861,13 8,11.209139 8,9 C8,6.790861 9.790861,5 12,5 C14.209139,5 16,6.790861 16,9 C16,11.209139 14.209139,13 12,13 Z"
-              fill="currentColor"
-            />
-          </svg>
+          <img
+            alt="edX"
+            className="pgn__avatar pgn__avatar-sm"
+            src="icon/mock/path"
+          />
         </span>
       </button>
     </nav>
@@ -536,39 +445,20 @@ exports[`<Header /> renders correctly for unauthenticated users on mobile 1`] = 
         aria-expanded={false}
         aria-haspopup="menu"
         aria-label="Account Menu"
-        className="menu-trigger icon-button"
+        className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md menu-trigger null pgn__avatar-button-hide-label btn btn-tertiary btn-md"
+        disabled={false}
         onClick={[Function]}
         title="Account Menu"
+        type="button"
       >
         <span
-          className="avatar overflow-hidden d-inline-flex rounded-circle null"
-          style={
-            Object {
-              "height": "1.5rem",
-              "width": "1.5rem",
-            }
-          }
+          className="pgn__avatar-button-avatar-wrap"
         >
-          <svg
-            aria-hidden={true}
-            focusable="false"
-            height="24px"
-            role="img"
-            style={
-              Object {
-                "height": "1.5rem",
-                "width": "1.5rem",
-              }
-            }
-            version="1.1"
-            viewBox="0 0 24 24"
-            width="24px"
-          >
-            <path
-              d="M4.10255106,18.1351061 C4.7170266,16.0581859 8.01891846,14.4720277 12,14.4720277 C15.9810815,14.4720277 19.2829734,16.0581859 19.8974489,18.1351061 C21.215206,16.4412566 22,14.3122775 22,12 C22,6.4771525 17.5228475,2 12,2 C6.4771525,2 2,6.4771525 2,12 C2,14.3122775 2.78479405,16.4412566 4.10255106,18.1351061 Z M12,24 C5.372583,24 0,18.627417 0,12 C0,5.372583 5.372583,0 12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 Z M12,13 C9.790861,13 8,11.209139 8,9 C8,6.790861 9.790861,5 12,5 C14.209139,5 16,6.790861 16,9 C16,11.209139 14.209139,13 12,13 Z"
-              fill="currentColor"
-            />
-          </svg>
+          <img
+            alt={null}
+            className="pgn__avatar pgn__avatar-sm"
+            src="icon/mock/path"
+          />
         </span>
       </button>
     </nav>


### PR DESCRIPTION
## What did we do?
We updated the mobile and desktop views of the header to use the newer Avatar button design. We also bumped the version of Paragon from 7 to 12 (a breaking change).

## Why are we doing this?
To use the newer Avatar button design instead of building our own. The Paragon update is because the newer Avatar button design isn't available until version 12.

JIRA ticket: https://openedx.atlassian.net/browse/REV-2070