### PR TITLE
build: update transifex pull translations command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --language=$(transifex_langs)
+	tx pull -f --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
### Description
- New Transifex client needs `languages` instead of `language` as a parameter so updating the command to run the translation job successfully.