### PR TITLE
`npm run build` script in Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
+    - name: Build
+      run: npm run build
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage


### PR DESCRIPTION
### Ticket
[Ensure npm run build is used in MFE repo build workflows](https://github.com/openedx/frontend-wg/issues/33)

### What has changed
Added `npm run build` script in github CI