### PR TITLE
Renovate config to automate @edx namespaced minor/patch version upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
         "pin"
       ],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["@edx"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ],
   "timezone": "America/New_York"


### PR DESCRIPTION
### Ticket
[Create common renovate config that automates @edx namespaced minor/patch version upgrades](https://github.com/openedx/frontend-wg/issues/116)

### What has changed
Added Renovate config to update and auto merge `@edx` name spaced minor and patch packages.
