### PR TITLE
fix:  Added id in dropdownToggle component

### DIFF
--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -65,7 +65,7 @@ class DesktopHeader extends React.Component {
     return (
       <Dropdown>
         <Dropdown.Toggle
-          id="Menu dropdown"
+          id="menu-dropdown"
           as={AvatarButton}
           src={avatar}
           alt=""

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -65,6 +65,7 @@ class DesktopHeader extends React.Component {
     return (
       <Dropdown>
         <Dropdown.Toggle
+          id="Menu dropdown"
           as={AvatarButton}
           src={avatar}
           alt=""

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -40,6 +40,7 @@ exports[`<Header /> minimal renders correctly for authenticated users when minim
             className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
             data-hj-suppress={true}
             disabled={false}
+            id="Menu dropdown"
             onClick={[Function]}
             type="button"
           >
@@ -168,6 +169,7 @@ exports[`<Header /> renders correctly for authenticated users on desktop 1`] = `
             className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
             data-hj-suppress={true}
             disabled={false}
+            id="Menu dropdown"
             onClick={[Function]}
             type="button"
           >

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`<Header /> minimal renders correctly for authenticated users when minim
             className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
             data-hj-suppress={true}
             disabled={false}
-            id="Menu dropdown"
+            id="menu-dropdown"
             onClick={[Function]}
             type="button"
           >
@@ -169,7 +169,7 @@ exports[`<Header /> renders correctly for authenticated users on desktop 1`] = `
             className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
             data-hj-suppress={true}
             disabled={false}
-            id="Menu dropdown"
+            id="menu-dropdown"
             onClick={[Function]}
             type="button"
           >

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -29,7 +29,7 @@ function AuthenticatedUserDropdown({ enterpriseLearnerPortalLink, intl, username
     <>
       <a className="text-gray-700 mr-3" href={`${getConfig().SUPPORT_URL}`}>{intl.formatMessage(messages.help)}</a>
       <Dropdown className="user-dropdown">
-        <Dropdown.Toggle variant="outline-primary">
+        <Dropdown.Toggle variant="outline-primary" id="User dropdown">
           <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
           <span data-hj-suppress className="d-none d-md-inline">
             {username}

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -29,7 +29,7 @@ function AuthenticatedUserDropdown({ enterpriseLearnerPortalLink, intl, username
     <>
       <a className="text-gray-700 mr-3" href={`${getConfig().SUPPORT_URL}`}>{intl.formatMessage(messages.help)}</a>
       <Dropdown className="user-dropdown">
-        <Dropdown.Toggle variant="outline-primary" id="User dropdown">
+        <Dropdown.Toggle variant="outline-primary" id="user-dropdown">
           <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
           <span data-hj-suppress className="d-none d-md-inline">
             {username}


### PR DESCRIPTION
Fixed the error:

```
The prop `id` is marked as required in `ForwardRef(DropdownToggle)`, but its value is `undefined`.
```

Stacktrace:
```
Warning: Failed prop type: The prop `id` is marked as required in `ForwardRef(DropdownToggle)`, but its value is `undefined`.
    in ForwardRef(DropdownToggle) (created by DesktopHeader)
    in DesktopHeader (created by ShimmedIntlComponent)
    in ShimmedIntlComponent (created by Context.Consumer)
    in injectIntl(ShimmedIntlComponent) (created by Header)
    in MediaQuery (created by Header)
    in Header (created by ShimmedIntlComponent)
    in ShimmedIntlComponent (created by Context.Consumer)
    in injectIntl(ShimmedIntlComponent)
    in Router (created by AppProvider)
    in Provider (created by OptionalReduxProvider)
    in OptionalReduxProvider (created by AppProvider)
    in ErrorBoundary (created by AppProvider)
    in IntlProvider (created by AppProvider)
    in AppProvider
```

**Testing Instructions:**

-   To test the change in `AuthenticatedUserDropdown` We can test it in Learning MFE via [link](https://learning.edx.org/course/course-v1:HarvardX+CS50+X/home)

![Screen Shot 2022-09-15 at 4 53 16 PM](https://user-images.githubusercontent.com/33825083/190398778-b2adef34-4f7b-40a3-aba8-00e78e8ee9e8.png)

- To test change in `DesktopHeader` we can test in Payment MFE via [link](https://payment.edx.org/)
![Screen Shot 2022-09-15 at 5 21 57 PM](https://user-images.githubusercontent.com/33825083/190402565-2193cb8c-c4e3-4d58-9aa8-a99845b0ee52.png)


    