### PR TITLE
-t flag added in pull translation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --languages=$(transifex_langs)
+	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
The transifex command line tool we use to pull translations introduced a fix that broke the existing translation pulls.
So, in order to fix this, I've updated the` tx pull `command to use the `-t` flag along with the existing flags.

To get the more context on this, please have a look into this [issue](https://github.com/edx/edx-arch-experiments/issues/77)