### PR TITLE
fix: added spinner when notifications are loading

### DIFF
--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -7,7 +7,7 @@ import messages from './messages';
 import NotificationRowItem from './NotificationRowItem';
 import { markAllNotificationsAsRead, fetchNotificationList } from './data/thunks';
 import {
-  selectNotificationsByIds, selectPaginationData, selectSelectedAppName, selectNotificationStatus,
+  selectNotificationsByIds, selectPaginationData, selectSelectedAppName, selectNotificationListStatus,
 } from './data/selectors';
 import { splitNotificationsByTime } from './utils';
 import { RequestStatus } from './data/slice';
@@ -16,7 +16,7 @@ const NotificationSections = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const selectedAppName = useSelector(selectSelectedAppName);
-  const notificationRequestStatus = useSelector(selectNotificationStatus);
+  const notificationRequestStatus = useSelector(selectNotificationListStatus);
   const notifications = useSelector(selectNotificationsByIds(selectedAppName));
   const { hasMorePages, currentPage } = useSelector(selectPaginationData);
   const { today = [], earlier = [] } = useMemo(
@@ -73,9 +73,9 @@ const NotificationSections = () => {
     <div className="mt-4 px-4" data-testid="notification-tray-section">
       {renderNotificationSection('today', today)}
       {renderNotificationSection('earlier', earlier)}
-      {hasMorePages && notificationRequestStatus === RequestStatus.IN_PROGRESS ? (
+      {(hasMorePages === undefined || hasMorePages) && notificationRequestStatus === RequestStatus.IN_PROGRESS ? (
         <div className="d-flex justify-content-center p-4">
-          <Spinner animation="border" variant="primary" size="lg" />
+          <Spinner animation="border" variant="primary" size="lg" data-testid="notifications-loading-spinner" />
         </div>
       ) : (hasMorePages && notificationRequestStatus === RequestStatus.SUCCESSFUL && (
         <Button

--- a/src/Notifications/data/redux.test.js
+++ b/src/Notifications/data/redux.test.js
@@ -73,9 +73,9 @@ describe('Notification Redux', () => {
     axiosMock.onGet(notificationsListApiUrl).reply(statusCode);
     await executeThunk(fetchNotificationList({ page: 1 }), store.dispatch, store.getState);
 
-    const { notifications: { notificationStatus } } = store.getState();
+    const { notifications: { notificationListStatus } } = store.getState();
 
-    expect(notificationStatus).toEqual(status);
+    expect(notificationListStatus).toEqual(status);
   });
 
   it('Successfully loaded notification counts in the redux.', async () => {

--- a/src/Notifications/data/selectors.js
+++ b/src/Notifications/data/selectors.js
@@ -2,6 +2,8 @@ import { createSelector } from '@reduxjs/toolkit';
 
 export const selectNotificationStatus = state => state.notifications.notificationStatus;
 
+export const selectNotificationListStatus = state => state.notifications.notificationListStatus;
+
 export const selectNotificationTabsCount = state => state.notifications.tabsCount;
 
 export const selectNotificationTabs = state => state.notifications.appsId;

--- a/src/Notifications/data/slice.js
+++ b/src/Notifications/data/slice.js
@@ -11,6 +11,7 @@ export const RequestStatus = {
 
 const initialState = {
   notificationStatus: RequestStatus.IDLE,
+  notificationListStatus: RequestStatus.IDLE,
   appName: 'discussion',
   appsId: [],
   apps: {},
@@ -35,6 +36,15 @@ const slice = createSlice({
     notificationStatusSuccess: (state) => {
       state.notificationStatus = RequestStatus.SUCCESSFUL;
     },
+    notificationListStatusRequest: (state) => {
+      state.notificationListStatus = RequestStatus.IN_PROGRESS;
+    },
+    notificationListStatusFailed: (state) => {
+      state.notificationListStatus = RequestStatus.FAILED;
+    },
+    notificationListStatusDenied: (state) => {
+      state.notificationListStatus = RequestStatus.DENIED;
+    },
     fetchNotificationSuccess: (state, { payload }) => {
       const {
         newNotificationIds, notificationsKeyValuePair, pagination,
@@ -44,7 +54,7 @@ const slice = createSlice({
       state.notifications = { ...state.notifications, ...notificationsKeyValuePair };
       state.tabsCount.count -= state.tabsCount[state.appName];
       state.tabsCount[state.appName] = 0;
-      state.notificationStatus = RequestStatus.SUCCESSFUL;
+      state.notificationListStatus = RequestStatus.SUCCESSFUL;
       state.pagination = pagination;
     },
     fetchNotificationsCountSuccess: (state, { payload }) => {
@@ -87,6 +97,9 @@ export const {
   notificationStatusFailed,
   notificationStatusDenied,
   notificationStatusSuccess,
+  notificationListStatusDenied,
+  notificationListStatusFailed,
+  notificationListStatusRequest,
   fetchNotificationSuccess,
   fetchNotificationsCountSuccess,
   markAllNotificationsAsReadSuccess,

--- a/src/Notifications/data/thunks.js
+++ b/src/Notifications/data/thunks.js
@@ -9,6 +9,9 @@ import {
   markAllNotificationsAsReadSuccess,
   markNotificationsAsReadSuccess,
   resetNotificationStateRequest,
+  notificationListStatusRequest,
+  notificationListStatusDenied,
+  notificationListStatusFailed,
 } from './slice';
 import {
   getNotificationsList, getNotificationCounts, markNotificationSeen, markAllNotificationRead, markNotificationRead,
@@ -47,12 +50,16 @@ const responseError = (error, dispatch) => {
 export const fetchNotificationList = ({ appName, page = 1, pageSize = 10 }) => (
   async (dispatch) => {
     try {
-      dispatch(notificationStatusRequest());
+      dispatch(notificationListStatusRequest());
       const data = await getNotificationsList(appName, page, pageSize);
       const normalizedData = normalizeNotifications((camelCaseObject(data)));
       dispatch(fetchNotificationSuccess({ ...normalizedData }));
     } catch (error) {
-      responseError(error, dispatch);
+      if (getHttpErrorStatus(error) === 403) {
+        dispatch(notificationListStatusDenied());
+      } else {
+        dispatch(notificationListStatusFailed());
+      }
     }
   }
 );


### PR DESCRIPTION
Fixed loading spinner was not visible when notifications are loading in notifications list.

Ticket: [INF-964](https://2u-internal.atlassian.net/browse/INF-964)