### PR TITLE
feat: tabs should stick to the top in the notification tray

### DIFF
--- a/src/Notifications/NotificationTabs.jsx
+++ b/src/Notifications/NotificationTabs.jsx
@@ -33,7 +33,7 @@ const NotificationTabs = () => {
       variant="tabs"
       defaultActiveKey={selectedAppName}
       onSelect={handleActiveTab}
-      className="px-2.5 text-primary-500"
+      className="px-2.5 text-primary-500 tabs position-sticky zIndex-2 bg-white"
     >
       {notificationTabs?.map((appName) => (
         <Tab

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -81,7 +81,11 @@ const Notifications = () => {
             })}
           >
             <div ref={popoverRef}>
-              <Popover.Title as="h2" className="d-flex justify-content-between p-0 m-4 border-0 text-primary-500 font-size-18 line-height-24">
+              <Popover.Title
+                as="h2"
+                className={`sticky-container d-flex justify-content-between p-4 m-0 border-0 text-primary-500 zIndex-2
+                  font-size-18 line-height-24 bg-white position-sticky`}
+              >
                 {intl.formatMessage(messages.notificationTitle)}
                 <Hyperlink
                   destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}

--- a/src/index.scss
+++ b/src/index.scss
@@ -190,6 +190,7 @@ $white: #fff;
 .notification-icon {
   height: 23.33px !important;
   width: 23.33px !important;
+  z-index: 1;
 }
 
 .notification-badge {
@@ -214,6 +215,14 @@ $white: #fff;
 .popover {
   filter: none;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15), 0px 2px 8px rgba(0, 0, 0, 0.15);
+
+  .popover-header{
+    top: 0px;
+  }
+
+  .tabs{
+    top: 72px;
+  }
 
   &.medium-screen {
     min-width: 24.313rem;


### PR DESCRIPTION
[INF-1002](https://2u-internal.atlassian.net/browse/INF-1002)

**Description**
To make navigation and scroll independent of each other, the tabs in the notifications tray stick to the top.

Mockup:[Notifications](https://www.figma.com/file/1WsIDaf9Alfy2r8eNYj6vX/Notifications?type=design&node-id=1544-13193&mode=design&t=Tv4seDEeQ3C3Fi9b-4)

**Screenshots**

<img width="596" alt="Screenshot 2023-08-16 at 10 09 22 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/ac31d0bc-2c03-40cf-8129-303f4b7331f9">
