### PR TITLE
feat: Notifications tray should stick to the top

### DIFF
--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -45,7 +45,7 @@ const NotificationSections = () => {
           {notifications?.length > 0 && (section === 'earlier' ? today.length === 0 : true) && (
             <Button
               variant="link"
-              className="text-info-500 font-size-14 line-height-10 text-decoration-none p-0 border-0"
+              className="font-size-14 line-height-10 text-decoration-none p-0 border-0 text-info-500"
               onClick={handleMarkAllAsRead}
               data-testid="mark-all-read"
             >

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, {
-  useCallback, useEffect, useRef, useState,
+  useCallback, useEffect, useRef, useState, useMemo,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -52,23 +52,24 @@ const Notifications = () => {
   const viewPortHeight = document.body.clientHeight;
   const headerHeight = document.getElementsByClassName('learning-header-container');
   const footer = document.getElementsByClassName('footer');
-  let notificationBarHeight = 0;
 
-  if (headerHeight.length > 0) {
-    const availableViewportHeight = viewPortHeight - headerHeight[0].clientHeight;
+  const notificationBarHeight = useMemo(() => {
+    if (headerHeight.length > 0) {
+      const availableViewportHeight = viewPortHeight - headerHeight[0].clientHeight;
 
-    if (footer.length > 0) {
-      const footerRect = footer[0].getBoundingClientRect();
-      const visibleFooterHeight = Math.min(footerRect.bottom, window.innerHeight) - Math.max(footerRect.top, 0);
-      const footerHeight = footer[0].clientHeight;
+      if (footer.length > 0) {
+        const footerRect = footer[0].getBoundingClientRect();
+        const visibleFooterHeight = Math.min(footerRect.bottom, window.innerHeight) - Math.max(footerRect.top, 0);
+        const footerHeight = footer[0].clientHeight;
 
-      const adjustedBarHeight = availableViewportHeight - footerHeight + Math.min(visibleFooterHeight, 0);
+        const adjustedBarHeight = availableViewportHeight - footerHeight + Math.min(visibleFooterHeight, 0);
 
-      notificationBarHeight = adjustedBarHeight;
-    } else {
-      notificationBarHeight = availableViewportHeight;
+        return adjustedBarHeight;
+      }
+      return availableViewportHeight;
     }
-  }
+    return 0;
+  }, [viewPortHeight, headerHeight, footer]);
 
   const enableFeedback = useCallback(() => {
     window.usabilla_live('click');

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -55,9 +55,18 @@ const Notifications = () => {
   let notificationBarHeight = 0;
 
   if (headerHeight.length > 0) {
-    notificationBarHeight = viewPortHeight - headerHeight[0].clientHeight;
+    const availableViewportHeight = viewPortHeight - headerHeight[0].clientHeight;
+
     if (footer.length > 0) {
-      notificationBarHeight -= footer[0].clientHeight;
+      const footerRect = footer[0].getBoundingClientRect();
+      const visibleFooterHeight = Math.min(footerRect.bottom, window.innerHeight) - Math.max(footerRect.top, 0);
+      const footerHeight = footer[0].clientHeight;
+
+      const adjustedBarHeight = availableViewportHeight - footerHeight + Math.min(visibleFooterHeight, 0);
+
+      notificationBarHeight = adjustedBarHeight;
+    } else {
+      notificationBarHeight = availableViewportHeight;
     }
   }
 
@@ -78,7 +87,7 @@ const Notifications = () => {
             id="notificationTray"
             style={{ height: `${notificationBarHeight}px` }}
             data-testid="notification-tray"
-            className={classNames('overflow-auto rounded-0 border-0', {
+            className={classNames('overflow-auto rounded-0 border-0 position-fixed', {
               'w-100': !isOnMediumScreen && !isOnLargeScreen,
               'medium-screen': isOnMediumScreen,
               'large-screen': isOnLargeScreen,
@@ -87,8 +96,8 @@ const Notifications = () => {
             <div ref={popoverRef}>
               <Popover.Title
                 as="h2"
-                className={`sticky-container d-flex justify-content-between p-4 m-0 border-0 text-primary-500 zIndex-2
-                  font-size-18 line-height-24 bg-white position-sticky`}
+                className={`d-flex justify-content-between p-4 m-0 border-0 text-primary-500 zIndex-2 font-size-18
+                  line-height-24 bg-white position-sticky`}
               >
                 {intl.formatMessage(messages.notificationTitle)}
                 {getConfig().NOTIFICATION_FEEDBACK_URL && (

--- a/src/index.scss
+++ b/src/index.scss
@@ -134,11 +134,11 @@ $white: #fff;
 }
 
 .font-size-12 {
-  font-size: 12px;
+  font-size: 12px !important;
 }
 
 .font-size-14 {
-  font-size: 14px;
+  font-size: 14px !important;
 }
 
 .py-10px {


### PR DESCRIPTION
[INF-1001](https://2u-internal.atlassian.net/browse/INF-1001)

**Description**
Notification tray sticks to the top when the entire page is scrolled down.

**Screenshot**
<img width="1679" alt="Screenshot 2023-08-30 at 1 24 30 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/5ab62577-8c69-474c-b67c-9e664f48bd9b">

<img width="1679" alt="Screenshot 2023-08-30 at 1 24 22 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/28ae96d5-d798-41ee-86ab-045256e4de43">
