### PR TITLE
fix: update notification tour text and documentation link

### DIFF
--- a/src/Notifications/tours/constants.js
+++ b/src/Notifications/tours/constants.js
@@ -11,21 +11,33 @@ export default function tourCheckpoints(intl) {
       {
         body: (
           <>
-            {intl.formatMessage(messages.notificationTourBody)}
-            <Hyperlink
-              destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
-              target="_blank"
-              rel="noopener noreferrer"
-              showLaunchIcon={false}
-              className="d-inline-block pl-1.5"
-            >
-              <Icon
-                src={Settings}
-                className="icon-size-20 text-primary-500"
-                data-testid="tour-setting-icon"
-                screenReaderText="preferences settings icon"
-              />
-            </Hyperlink>
+            <p>
+              {intl.formatMessage(messages.notificationTourPreferenceBody)}
+              <Hyperlink
+                destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+                target="_blank"
+                rel="noopener noreferrer"
+                showLaunchIcon={false}
+                className="d-inline-block px-1.5"
+              >
+                <Icon
+                  src={Settings}
+                  className="icon-size-20 text-primary-500"
+                  data-testid="tour-setting-icon"
+                  screenReaderText="preferences settings icon"
+                />
+              </Hyperlink>
+            </p>
+            <p>
+              {intl.formatMessage(messages.notificationTourGuideBody)}
+              <Hyperlink
+                destination="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/sfd_notifications/managing_notifications.html"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {intl.formatMessage(messages.notificationTourGuideLink)}
+              </Hyperlink>
+            </p>
           </>
         ),
         placement: 'left',

--- a/src/Notifications/tours/messages.js
+++ b/src/Notifications/tours/messages.js
@@ -16,10 +16,20 @@ const messages = defineMessages({
     defaultMessage: 'Okay',
     description: 'Action to end current tour',
   },
-  notificationTourBody: {
-    id: 'notification.tour.body',
-    defaultMessage: 'Click the bell icon to see Discussion notifications and customize your preferences by clicking on the gear icon',
-    description: 'Body of the tour for the notification',
+  notificationTourPreferenceBody: {
+    id: 'notification.tour.preference.body',
+    defaultMessage: 'Click the bell icon to see Discussion notifications and customize your preferences by clicking on the gear icon.',
+    description: 'Body of the tour for the notification preferences',
+  },
+  notificationTourGuideBody: {
+    id: 'notification.tour.guide.body',
+    defaultMessage: 'Certain notifications are enabled by default, as further detailed in the ',
+    description: 'Body of the tour for the notification for the guide',
+  },
+  notificationTourGuideLink: {
+    id: 'notification.tour.guide.link',
+    defaultMessage: "edX Learner's Guide.",
+    description: 'Link of the tour for the notification for the guide',
   },
   notificationTourTitle: {
     id: 'notification.tour.title',


### PR DESCRIPTION
[INF-1023](https://2u-internal.atlassian.net/browse/INF-1023)

1. Update the tour text 
2. Add learner's guide link

<img width="532" alt="Screenshot 2023-09-05 at 4 18 15 PM" src="https://github.com/edx/frontend-component-header-edx/assets/79941147/d15ae8e7-b570-48f0-96c4-7921763ba709">
