### PR TITLE
fix: fixed focus state bell color

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -193,8 +193,11 @@ $white: #fff;
 }
 
 .notification-button {
-  width: 36px;
-  height: 36px;
+  width: 36px !important;
+  height: 36px !important;
+  &:focus, &:active {
+    box-shadow: inset 0 0 0 2px #00262B !important;
+  }
 }
 
 .notification-icon {


### PR DESCRIPTION
[INF-1051](https://2u-internal.atlassian.net/browse/INF-1051)

**Description**
Currently the focus state contrast is not high enough for accessibility standards (see picture). Use Primary/500 (#00262B)

Now focus state is using Primary/500 (#00262B) color.

**Screenshot**
<img width="237" alt="Screenshot 2023-09-13 at 10 45 01 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/b923f5e8-5bbc-4a18-9bfd-120e4e0b8057">


