### PR TITLE
feat: Update Orders & Subscriptions menu item back to Order History

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -78,10 +78,10 @@ const Header = ({ intl }) => {
     content: intl.formatMessage(messages['header.user.menu.logout']),
   };
 
-  const ordersAndSubscriptionsItem = {
+  const orderHistoryItem = {
     type: 'item',
     href: config.ORDER_HISTORY_URL,
-    content: intl.formatMessage(messages['header.user.menu.order.subscriptions']),
+    content: intl.formatMessage(messages['header.user.menu.order.history']),
   };
 
   // If there is an Enterprise LP link, use that instead of the B2C Dashboard
@@ -122,10 +122,10 @@ const Header = ({ intl }) => {
   // Users should only see Order History if they do not have an available
   // learner portal and have a ORDER_HISTORY_URL define in the environment,
   // because an available learner portal currently means
-  // that they access content via Subscriptions, in which context an "order"
+  // that they access content via B2B Subscriptions, in which context an "order"
   // is not relevant.
   if (!enterpriseLearnerPortalLink && config.ORDER_HISTORY_URL) {
-    userMenu.splice(-1, 0, ordersAndSubscriptionsItem);
+    userMenu.splice(-1, 0, orderHistoryItem);
   }
 
   if (getConfig().MINIMAL_HEADER && authenticatedUser !== null) {

--- a/src/Header.messages.jsx
+++ b/src/Header.messages.jsx
@@ -46,10 +46,10 @@ const messages = defineMessages({
     defaultMessage: 'Account',
     description: 'Link to account settings',
   },
-  'header.user.menu.order.subscriptions': {
-    id: 'header.user.menu.order.subscriptions',
-    defaultMessage: 'Orders & Subscriptions',
-    description: 'Link to orders and subscriptions',
+  'header.user.menu.order.history': {
+    id: 'header.user.menu.order.history',
+    defaultMessage: 'Order History',
+    description: 'Link to order history',
   },
   'header.user.menu.logout': {
     id: 'header.user.menu.logout',

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -107,7 +107,7 @@ describe('<Header />', () => {
       wrapper.find('DropdownToggle').simulate('click');
     });
 
-    expect(wrapper.find('a[children="Orders & Subscriptions"]')).toHaveLength(1);
+    expect(wrapper.find('a[children="Order History"]')).toHaveLength(1);
     expect(wrapper.find('a[children="Dashboard"]')).toHaveLength(1);
 
     // When learner portal links are present, Order History should not be a dropdown item
@@ -121,7 +121,7 @@ describe('<Header />', () => {
       wrapper.update();
       wrapper.find('DropdownToggle').simulate('click');
     });
-    expect(wrapper.find('a[children="Orders & Subscriptions"]')).toHaveLength(0);
+    expect(wrapper.find('a[children="Order History"]')).toHaveLength(0);
     expect(wrapper.find('a[children="Dashboard"]')).toHaveLength(1);
   });
 

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -70,10 +70,10 @@ const AuthenticatedUserDropdown = ({ enterpriseLearnerPortalLink, intl, username
           {!enterpriseLearnerPortalLink && getConfig().ORDER_HISTORY_URL && (
             // Users should only see Order History if they do not have an available
             // learner portal, because an available learner portal currently means
-            // that they access content via Subscriptions, in which context an "order"
+            // that they access content via B2B Subscriptions, in which context an "order"
             // is not relevant.
             <Dropdown.Item href={getConfig().ORDER_HISTORY_URL}>
-              {intl.formatMessage(messages.ordersAndSubscriptions)}
+              {intl.formatMessage(messages.orderHistory)}
             </Dropdown.Item>
           )}
           <Dropdown.Item href={getConfig().LOGOUT_URL}>

--- a/src/learning-header/messages.js
+++ b/src/learning-header/messages.js
@@ -31,10 +31,10 @@ const messages = defineMessages({
     defaultMessage: 'New',
     description: 'The text announcing that an item in the user menu is New',
   },
-  ordersAndSubscriptions: {
-    id: 'header.menu.ordersAndSubscriptions.label',
-    defaultMessage: 'Orders & Subscriptions',
-    description: 'The text for the user menu Orders & Subscriptions navigation link.',
+  orderHistory: {
+    id: 'header.menu.orderHistory.label',
+    defaultMessage: 'Order History',
+    description: 'The text for the user menu Order History navigation link.',
   },
   skipNavLink: {
     id: 'header.navigation.skipNavLink',


### PR DESCRIPTION
[REV-3693](https://2u-internal.atlassian.net/browse/REV-3693).

Modifying the menu item back to `Order History` instead of `Orders & Subscriptions`.
This PR manually reverts changes done in https://github.com/edx/frontend-component-header-edx/pull/390