### PR TITLE
feat: added no notifition yet message bar

### DIFF
--- a/src/Notifications/NotificationEmptySection.jsx
+++ b/src/Notifications/NotificationEmptySection.jsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import PropTypes from 'prop-types';
 import { Icon, IconButton } from '@edx/paragon';
 import { NotificationsNone } from '@edx/paragon/icons';
+import NotificationContext from './context';
 import messages from './messages';
 
-const EmptyNotifications = ({ notificationRef, popoverHeaderRef }) => {
+const EmptyNotifications = () => {
   const intl = useIntl();
+  const { popoverHeaderRef, notificationRef } = useContext(NotificationContext);
 
   return (
     <div
@@ -16,7 +17,7 @@ const EmptyNotifications = ({ notificationRef, popoverHeaderRef }) => {
     >
       <IconButton
         isActive
-        alt="notification bell icon"
+        alt={intl.formatMessage(messages.notificationBellIconAltMessage)}
         src={NotificationsNone}
         iconAs={Icon}
         variant="light"
@@ -35,10 +36,6 @@ const EmptyNotifications = ({ notificationRef, popoverHeaderRef }) => {
       </div>
     </div>
   );
-};
-EmptyNotifications.propTypes = {
-  notificationRef: PropTypes.number.isRequired,
-  popoverHeaderRef: PropTypes.string.isRequired,
 };
 
 export default React.memo(EmptyNotifications);

--- a/src/Notifications/NotificationEmptySection.jsx
+++ b/src/Notifications/NotificationEmptySection.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
+import { Icon, IconButton } from '@edx/paragon';
+import { NotificationsNone } from '@edx/paragon/icons';
+import messages from './messages';
+
+const EmptyNotifications = ({ notificationRef, popoverHeaderRef }) => {
+  const intl = useIntl();
+
+  return (
+    <div
+      className="d-flex flex-column justify-content-center align-items-center"
+      data-testid="notifications-list-complete"
+      style={{ height: `${notificationRef.current.clientHeight - popoverHeaderRef.current.clientHeight}px` }}
+    >
+      <IconButton
+        isActive
+        alt="notification bell icon"
+        src={NotificationsNone}
+        iconAs={Icon}
+        variant="light"
+        id="bell-icon"
+        iconClassNames="text-primary-500"
+        className="ml-4 mr-1 notification-button notification-lg-bell-icon"
+        data-testid="notification-bell-icon"
+      />
+      <div className="mx-auto mt-3.5 mb-3 font-size-22 notification-end-title line-height-24">
+        {intl.formatMessage(messages.noNotificationsYetMessage)}
+      </div>
+      <div className="d-flex flex-row mx-auto text-gray-500">
+        <span className="font-size-14 line-height-normal">
+          {intl.formatMessage(messages.noNotificationHelpMessage)}
+        </span>
+      </div>
+    </div>
+  );
+};
+EmptyNotifications.propTypes = {
+  notificationRef: PropTypes.number.isRequired,
+  popoverHeaderRef: PropTypes.string.isRequired,
+};
+
+export default React.memo(EmptyNotifications);

--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
-import {
-  Button, Icon, Spinner, IconButton,
-} from '@edx/paragon';
-import { AutoAwesome, CheckCircleLightOutline, NotificationsNone } from '@edx/paragon/icons';
+import { Button, Icon, Spinner } from '@edx/paragon';
+import { AutoAwesome, CheckCircleLightOutline } from '@edx/paragon/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -10,6 +8,7 @@ import isEmpty from 'lodash/isEmpty';
 import classNames from 'classnames';
 import messages from './messages';
 import NotificationRowItem from './NotificationRowItem';
+import NotificationEmptySection from './NotificationEmptySection';
 import { markAllNotificationsAsRead, fetchNotificationList } from './data/thunks';
 import {
   selectExpiryDays, selectNotificationsByIds, selectPaginationData,
@@ -18,7 +17,7 @@ import {
 import { splitNotificationsByTime } from './utils';
 import { RequestStatus } from './data/slice';
 
-const NotificationSections = ({ popoverHeaderRef }) => {
+const NotificationSections = ({ popoverHeaderRef, notificationRef }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const selectedAppName = useSelector(selectSelectedAppName);
@@ -31,7 +30,6 @@ const NotificationSections = ({ popoverHeaderRef }) => {
     () => splitNotificationsByTime(notifications),
     [notifications],
   );
-  const trayRef = document.getElementById('notificationTray');
 
   const handleMarkAllAsRead = useCallback(() => {
     dispatch(markAllNotificationsAsRead(selectedAppName));
@@ -78,6 +76,11 @@ const NotificationSections = ({ popoverHeaderRef }) => {
     );
   };
 
+  const shouldRenderEmptyNotifications = notifications.length === 0
+    && notificationRequestStatus === RequestStatus.SUCCESSFUL
+    && notificationRef?.current
+    && popoverHeaderRef?.current;
+
   return (
     <div
       className={classNames('px-4', {
@@ -123,34 +126,8 @@ const NotificationSections = ({ popoverHeaderRef }) => {
         )
       }
 
-      {notifications.length === 0 && notificationRequestStatus === RequestStatus.SUCCESSFUL
-       && trayRef && popoverHeaderRef && popoverHeaderRef.current && (
-       <div
-         className="d-flex flex-column justify-content-center align-items-center"
-         data-testid="notifications-list-complete"
-         style={{ height: `${trayRef.clientHeight - popoverHeaderRef.current.clientHeight}px` }}
-       >
-         <IconButton
-           isActive
-           alt="notification bell icon"
-           src={NotificationsNone}
-           iconAs={Icon}
-           variant="light"
-           id="bell-icon"
-           iconClassNames="text-primary-500"
-           className="ml-4 mr-1 notification-button notification-lg-bell-icon"
-           data-testid="notification-bell-icon"
-         />
-         <div className="mx-auto mt-3.5 mb-3 font-size-22 notification-end-title line-height-24">
-           {intl.formatMessage(messages.noNotificationsYetMessage)}
-         </div>
-         <div className="d-flex flex-row mx-auto text-gray-500">
-           <span className="font-size-14 line-height-normal">
-             {intl.formatMessage(messages.noNotificationHelpMessage)}
-           </span>
-         </div>
-       </div>
-      )}
+      {shouldRenderEmptyNotifications
+       && <NotificationEmptySection notificationRef={notificationRef} popoverHeaderRef={popoverHeaderRef} />}
     </div>
   );
 };
@@ -160,10 +137,15 @@ NotificationSections.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
+  notificationRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
+  ]),
 };
 
 NotificationSections.defaultProps = {
   popoverHeaderRef: null,
+  notificationRef: null,
 };
 
 export default React.memo(NotificationSections);

--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/forbid-prop-types */
 import React, { useCallback, useMemo } from 'react';
 import {
   Button, Icon, Spinner, IconButton,
@@ -125,7 +124,7 @@ const NotificationSections = ({ popoverHeaderRef }) => {
       }
 
       {notifications.length === 0 && notificationRequestStatus === RequestStatus.SUCCESSFUL
-       && trayRef && popoverHeaderRef.current && (
+       && trayRef && popoverHeaderRef && popoverHeaderRef.current && (
        <div
          className="d-flex flex-column justify-content-center align-items-center"
          data-testid="notifications-list-complete"
@@ -157,7 +156,10 @@ const NotificationSections = ({ popoverHeaderRef }) => {
 };
 
 NotificationSections.propTypes = {
-  popoverHeaderRef: PropTypes.object,
+  popoverHeaderRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
+  ]),
 };
 
 NotificationSections.defaultProps = {

--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -1,11 +1,11 @@
-import React, {
-  useCallback, useMemo, useState, useEffect,
-} from 'react';
+/* eslint-disable react/forbid-prop-types */
+import React, { useCallback, useMemo } from 'react';
 import {
   Button, Icon, Spinner, IconButton,
 } from '@edx/paragon';
 import { AutoAwesome, CheckCircleLightOutline, NotificationsNone } from '@edx/paragon/icons';
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import isEmpty from 'lodash/isEmpty';
 import classNames from 'classnames';
@@ -19,10 +19,9 @@ import {
 import { splitNotificationsByTime } from './utils';
 import { RequestStatus } from './data/slice';
 
-const NotificationSections = () => {
+const NotificationSections = ({ popoverHeaderRef }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const [noNotificationDivHeight, setNoNotificationDivHeight] = useState(0);
   const selectedAppName = useSelector(selectSelectedAppName);
   const notificationRequestStatus = useSelector(selectNotificationListStatus);
   const notifications = useSelector(selectNotificationsByIds(selectedAppName));
@@ -33,15 +32,7 @@ const NotificationSections = () => {
     () => splitNotificationsByTime(notifications),
     [notifications],
   );
-
-  useEffect(() => {
-    const notificationTrayElement = document.getElementById('notificationTray');
-    const header = document.getElementsByClassName('popover-header');
-
-    if (notificationTrayElement && header.length > 0) {
-      setNoNotificationDivHeight(notificationTrayElement.clientHeight - header[0].clientHeight);
-    }
-  }, []);
+  const trayRef = document.getElementById('notificationTray');
 
   const handleMarkAllAsRead = useCallback(() => {
     dispatch(markAllNotificationsAsRead(selectedAppName));
@@ -133,35 +124,44 @@ const NotificationSections = () => {
         )
       }
 
-      {notifications.length === 0 && notificationRequestStatus === RequestStatus.SUCCESSFUL && (
-      <div
-        className="d-flex flex-column justify-content-center align-items-center"
-        data-testid="notifications-list-complete"
-        style={{ height: `${noNotificationDivHeight}px` }}
-      >
-        <IconButton
-          isActive
-          alt="notification bell icon"
-          src={NotificationsNone}
-          iconAs={Icon}
-          variant="light"
-          id="bell-icon"
-          iconClassNames="text-primary-500"
-          className="ml-4 mr-1 notification-button notification-lg-bell-icon"
-          data-testid="notification-bell-icon"
-        />
-        <div className="mx-auto mt-3.5 mb-3 font-size-22 notification-end-title line-height-24">
-          {intl.formatMessage(messages.noNotificationsYetMessage)}
-        </div>
-        <div className="d-flex flex-row mx-auto text-gray-500">
-          <span className="font-size-14 line-height-normal">
-            {intl.formatMessage(messages.noNotificationHelpMessage)}
-          </span>
-        </div>
-      </div>
+      {notifications.length === 0 && notificationRequestStatus === RequestStatus.SUCCESSFUL
+       && trayRef && popoverHeaderRef.current && (
+       <div
+         className="d-flex flex-column justify-content-center align-items-center"
+         data-testid="notifications-list-complete"
+         style={{ height: `${trayRef.clientHeight - popoverHeaderRef.current.clientHeight}px` }}
+       >
+         <IconButton
+           isActive
+           alt="notification bell icon"
+           src={NotificationsNone}
+           iconAs={Icon}
+           variant="light"
+           id="bell-icon"
+           iconClassNames="text-primary-500"
+           className="ml-4 mr-1 notification-button notification-lg-bell-icon"
+           data-testid="notification-bell-icon"
+         />
+         <div className="mx-auto mt-3.5 mb-3 font-size-22 notification-end-title line-height-24">
+           {intl.formatMessage(messages.noNotificationsYetMessage)}
+         </div>
+         <div className="d-flex flex-row mx-auto text-gray-500">
+           <span className="font-size-14 line-height-normal">
+             {intl.formatMessage(messages.noNotificationHelpMessage)}
+           </span>
+         </div>
+       </div>
       )}
     </div>
   );
+};
+
+NotificationSections.propTypes = {
+  popoverHeaderRef: PropTypes.object,
+};
+
+NotificationSections.defaultProps = {
+  popoverHeaderRef: null,
 };
 
 export default React.memo(NotificationSections);

--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useContext } from 'react';
 import { Button, Icon, Spinner } from '@edx/paragon';
 import { AutoAwesome, CheckCircleLightOutline } from '@edx/paragon/icons';
 import { useDispatch, useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import isEmpty from 'lodash/isEmpty';
 import classNames from 'classnames';
@@ -16,8 +15,9 @@ import {
 } from './data/selectors';
 import { splitNotificationsByTime } from './utils';
 import { RequestStatus } from './data/slice';
+import NotificationContext from './context';
 
-const NotificationSections = ({ popoverHeaderRef, notificationRef }) => {
+const NotificationSections = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const selectedAppName = useSelector(selectSelectedAppName);
@@ -26,6 +26,7 @@ const NotificationSections = ({ popoverHeaderRef, notificationRef }) => {
   const { hasMorePages, currentPage } = useSelector(selectPaginationData);
   const notificationTabs = useSelector(selectNotificationTabs);
   const expiryDays = useSelector(selectExpiryDays);
+  const { popoverHeaderRef, notificationRef } = useContext(NotificationContext);
   const { today = [], earlier = [] } = useMemo(
     () => splitNotificationsByTime(notifications),
     [notifications],
@@ -126,26 +127,9 @@ const NotificationSections = ({ popoverHeaderRef, notificationRef }) => {
         )
       }
 
-      {shouldRenderEmptyNotifications
-       && <NotificationEmptySection notificationRef={notificationRef} popoverHeaderRef={popoverHeaderRef} />}
+      {shouldRenderEmptyNotifications && <NotificationEmptySection />}
     </div>
   );
-};
-
-NotificationSections.propTypes = {
-  popoverHeaderRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
-  ]),
-  notificationRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
-  ]),
-};
-
-NotificationSections.defaultProps = {
-  popoverHeaderRef: null,
-  notificationRef: null,
 };
 
 export default React.memo(NotificationSections);

--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -1,9 +1,14 @@
-import React, { useCallback, useMemo } from 'react';
-import { Button, Icon, Spinner } from '@edx/paragon';
-import { AutoAwesome, CheckCircleLightOutline } from '@edx/paragon/icons';
+import React, {
+  useCallback, useMemo, useState, useEffect,
+} from 'react';
+import {
+  Button, Icon, Spinner, IconButton,
+} from '@edx/paragon';
+import { AutoAwesome, CheckCircleLightOutline, NotificationsNone } from '@edx/paragon/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import isEmpty from 'lodash/isEmpty';
+import classNames from 'classnames';
 import messages from './messages';
 import NotificationRowItem from './NotificationRowItem';
 import { markAllNotificationsAsRead, fetchNotificationList } from './data/thunks';
@@ -17,6 +22,7 @@ import { RequestStatus } from './data/slice';
 const NotificationSections = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
+  const [noNotificationDivHeight, setNoNotificationDivHeight] = useState(0);
   const selectedAppName = useSelector(selectSelectedAppName);
   const notificationRequestStatus = useSelector(selectNotificationListStatus);
   const notifications = useSelector(selectNotificationsByIds(selectedAppName));
@@ -27,6 +33,15 @@ const NotificationSections = () => {
     () => splitNotificationsByTime(notifications),
     [notifications],
   );
+
+  useEffect(() => {
+    const notificationTrayElement = document.getElementById('notificationTray');
+    const header = document.getElementsByClassName('popover-header');
+
+    if (notificationTrayElement && header.length > 0) {
+      setNoNotificationDivHeight(notificationTrayElement.clientHeight - header[0].clientHeight);
+    }
+  }, []);
 
   const handleMarkAllAsRead = useCallback(() => {
     dispatch(markAllNotificationsAsRead(selectedAppName));
@@ -74,7 +89,13 @@ const NotificationSections = () => {
   };
 
   return (
-    <div className={`${notificationTabs.length > 1 && 'mt-4'} px-4 pb-3.5`} data-testid="notification-tray-section">
+    <div
+      className={classNames('px-4', {
+        'mt-4': notificationTabs.length > 1,
+        'pb-3.5': notifications.length > 0,
+      })}
+      data-testid="notification-tray-section"
+    >
       {renderNotificationSection('today', today)}
       {renderNotificationSection('earlier', earlier)}
       {(hasMorePages === undefined || hasMorePages) && notificationRequestStatus === RequestStatus.IN_PROGRESS ? (
@@ -93,7 +114,7 @@ const NotificationSections = () => {
       )
       )}
       {
-        !hasMorePages && notificationRequestStatus === RequestStatus.SUCCESSFUL && (
+        notifications.length > 0 && !hasMorePages && notificationRequestStatus === RequestStatus.SUCCESSFUL && (
           <div
             className="d-flex flex-column my-5"
             data-testid="notifications-list-complete"
@@ -111,6 +132,34 @@ const NotificationSections = () => {
           </div>
         )
       }
+
+      {notifications.length === 0 && notificationRequestStatus === RequestStatus.SUCCESSFUL && (
+      <div
+        className="d-flex flex-column justify-content-center align-items-center"
+        data-testid="notifications-list-complete"
+        style={{ height: `${noNotificationDivHeight}px` }}
+      >
+        <IconButton
+          isActive
+          alt="notification bell icon"
+          src={NotificationsNone}
+          iconAs={Icon}
+          variant="light"
+          id="bell-icon"
+          iconClassNames="text-primary-500"
+          className="ml-4 mr-1 notification-button notification-lg-bell-icon"
+          data-testid="notification-bell-icon"
+        />
+        <div className="mx-auto mt-3.5 mb-3 font-size-22 notification-end-title line-height-24">
+          {intl.formatMessage(messages.noNotificationsYetMessage)}
+        </div>
+        <div className="d-flex flex-row mx-auto text-gray-500">
+          <span className="font-size-14 line-height-normal">
+            {intl.formatMessage(messages.noNotificationHelpMessage)}
+          </span>
+        </div>
+      </div>
+      )}
     </div>
   );
 };

--- a/src/Notifications/NotificationTabs.jsx
+++ b/src/Notifications/NotificationTabs.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/forbid-prop-types */
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Tab, Tabs } from '@edx/paragon';
@@ -60,7 +59,10 @@ const NotificationTabs = ({ popoverHeaderRef }) => {
 };
 
 NotificationTabs.propTypes = {
-  popoverHeaderRef: PropTypes.object,
+  popoverHeaderRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
+  ]),
 };
 
 NotificationTabs.defaultProps = {

--- a/src/Notifications/NotificationTabs.jsx
+++ b/src/Notifications/NotificationTabs.jsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Tab, Tabs } from '@edx/paragon';
-import PropTypes from 'prop-types';
 import NotificationSections from './NotificationSections';
 import { fetchNotificationList, markNotificationsAsSeen } from './data/thunks';
 import {
@@ -10,7 +9,7 @@ import {
 import { updateAppNameRequest, toggleTrayEvent } from './data/slice';
 import { useFeedbackWrapper } from './utils';
 
-const NotificationTabs = ({ popoverHeaderRef, notificationRef }) => {
+const NotificationTabs = () => {
   useFeedbackWrapper();
   const dispatch = useDispatch();
   const selectedAppName = useSelector(selectSelectedAppName);
@@ -54,24 +53,8 @@ const NotificationTabs = ({ popoverHeaderRef, notificationRef }) => {
           ))}
         </Tabs>
       )
-      : <NotificationSections popoverHeaderRef={popoverHeaderRef} notificationRef={notificationRef} />
+      : <NotificationSections />
   );
-};
-
-NotificationTabs.propTypes = {
-  popoverHeaderRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
-  ]),
-  notificationRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
-  ]),
-};
-
-NotificationTabs.defaultProps = {
-  popoverHeaderRef: null,
-  notificationRef: null,
 };
 
 export default React.memo(NotificationTabs);

--- a/src/Notifications/NotificationTabs.jsx
+++ b/src/Notifications/NotificationTabs.jsx
@@ -10,7 +10,7 @@ import {
 import { updateAppNameRequest, toggleTrayEvent } from './data/slice';
 import { useFeedbackWrapper } from './utils';
 
-const NotificationTabs = ({ popoverHeaderRef }) => {
+const NotificationTabs = ({ popoverHeaderRef, notificationRef }) => {
   useFeedbackWrapper();
   const dispatch = useDispatch();
   const selectedAppName = useSelector(selectSelectedAppName);
@@ -54,7 +54,7 @@ const NotificationTabs = ({ popoverHeaderRef }) => {
           ))}
         </Tabs>
       )
-      : <NotificationSections popoverHeaderRef={popoverHeaderRef} />
+      : <NotificationSections popoverHeaderRef={popoverHeaderRef} notificationRef={notificationRef} />
   );
 };
 
@@ -63,10 +63,15 @@ NotificationTabs.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
+  notificationRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
+  ]),
 };
 
 NotificationTabs.defaultProps = {
   popoverHeaderRef: null,
+  notificationRef: null,
 };
 
 export default React.memo(NotificationTabs);

--- a/src/Notifications/NotificationTabs.jsx
+++ b/src/Notifications/NotificationTabs.jsx
@@ -1,6 +1,8 @@
+/* eslint-disable react/forbid-prop-types */
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Tab, Tabs } from '@edx/paragon';
+import PropTypes from 'prop-types';
 import NotificationSections from './NotificationSections';
 import { fetchNotificationList, markNotificationsAsSeen } from './data/thunks';
 import {
@@ -9,7 +11,7 @@ import {
 import { updateAppNameRequest, toggleTrayEvent } from './data/slice';
 import { useFeedbackWrapper } from './utils';
 
-const NotificationTabs = () => {
+const NotificationTabs = ({ popoverHeaderRef }) => {
   useFeedbackWrapper();
   const dispatch = useDispatch();
   const selectedAppName = useSelector(selectSelectedAppName);
@@ -53,8 +55,16 @@ const NotificationTabs = () => {
           ))}
         </Tabs>
       )
-      : <NotificationSections />
+      : <NotificationSections popoverHeaderRef={popoverHeaderRef} />
   );
+};
+
+NotificationTabs.propTypes = {
+  popoverHeaderRef: PropTypes.object,
+};
+
+NotificationTabs.defaultProps = {
+  popoverHeaderRef: null,
 };
 
 export default React.memo(NotificationTabs);

--- a/src/Notifications/context.js
+++ b/src/Notifications/context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const NotificationContext = React.createContext({ popoverHeaderRef: null, notificationRef: null });
+
+export default NotificationContext;

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -211,13 +211,13 @@ const Notifications = () => {
         overlay={(
           <Popover
             id="notificationTray"
-            style={{ height: isHeaderVisible ? '91vh' : '100vh' }}
             data-testid="notification-tray"
             className={classNames('overflow-auto rounded-0 border-0 position-fixed', {
               'w-100': !isOnMediumScreen && !isOnLargeScreen,
               'medium-screen': isOnMediumScreen,
               'large-screen': isOnLargeScreen,
-              'popover-margin-top': !isHeaderVisible,
+              'popover-margin-top height-100vh': !isHeaderVisible,
+              'height-91vh ': isHeaderVisible,
             })}
           >
             <div ref={popoverRef} className="height-inherit">

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -1,7 +1,6 @@
-/* eslint-disable react/jsx-no-constructed-context-values */
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, {
-  useCallback, useEffect, useRef, useState,
+  useCallback, useEffect, useRef, useState, useMemo,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -202,6 +201,11 @@ const Notifications = () => {
     window.usabilla_live('click');
   }, []);
 
+  const notificationRefs = useMemo(
+    () => ({ popoverHeaderRef: headerRef, notificationRef: popoverRef }),
+    [headerRef, popoverRef],
+  );
+
   return (
     <>
       <OverlayTrigger
@@ -246,7 +250,7 @@ const Notifications = () => {
                 </Popover.Title>
               </div>
               <Popover.Content className="notification-content p-0">
-                <NotificationContext.Provider value={{ popoverHeaderRef: headerRef, notificationRef: popoverRef }}>
+                <NotificationContext.Provider value={notificationRefs}>
                   <NotificationTabs />
                 </NotificationContext.Provider>
               </Popover.Content>

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -220,7 +220,7 @@ const Notifications = () => {
               'popover-margin-top': !isHeaderVisible,
             })}
           >
-            <div ref={popoverRef}>
+            <div ref={popoverRef} className="height-inherit">
               <div ref={headerRef}>
                 <Popover.Title
                   as="h2"
@@ -244,7 +244,7 @@ const Notifications = () => {
                 </Popover.Title>
               </div>
               <Popover.Content className="notification-content p-0">
-                <NotificationTabs popoverHeaderRef={headerRef} />
+                <NotificationTabs popoverHeaderRef={headerRef} notificationRef={popoverRef} />
               </Popover.Content>
               {getConfig().NOTIFICATION_FEEDBACK_URL && (
                 <Button

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -22,6 +22,7 @@ const Notifications = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const popoverRef = useRef(null);
+  const headerRef = useRef(null);
   const buttonRef = useRef(null);
   const [enableNotificationTray, setEnableNotificationTray] = useState(false);
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
@@ -220,28 +221,30 @@ const Notifications = () => {
             })}
           >
             <div ref={popoverRef}>
-              <Popover.Title
-                as="h2"
-                className={`d-flex justify-content-between p-4 m-0 border-0 text-primary-500 zIndex-2 font-size-18
+              <div ref={headerRef}>
+                <Popover.Title
+                  as="h2"
+                  className={`d-flex justify-content-between p-4 m-0 border-0 text-primary-500 zIndex-2 font-size-18
                   line-height-24 bg-white position-sticky`}
-              >
-                {intl.formatMessage(messages.notificationTitle)}
-                <Hyperlink
-                  destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  showLaunchIcon={false}
                 >
-                  <Icon
-                    src={Settings}
-                    className="icon-size-20 text-primary-500"
-                    data-testid="setting-icon"
-                    screenReaderText="preferences settings icon"
-                  />
-                </Hyperlink>
-              </Popover.Title>
+                  {intl.formatMessage(messages.notificationTitle)}
+                  <Hyperlink
+                    destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    showLaunchIcon={false}
+                  >
+                    <Icon
+                      src={Settings}
+                      className="icon-size-20 text-primary-500"
+                      data-testid="setting-icon"
+                      screenReaderText="preferences settings icon"
+                    />
+                  </Hyperlink>
+                </Popover.Title>
+              </div>
               <Popover.Content className="notification-content p-0">
-                <NotificationTabs />
+                <NotificationTabs popoverHeaderRef={headerRef} />
               </Popover.Content>
               {getConfig().NOTIFICATION_FEEDBACK_URL && (
                 <Button

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-constructed-context-values */
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, {
   useCallback, useEffect, useRef, useState,
@@ -17,6 +18,7 @@ import { useIsOnLargeScreen, useIsOnMediumScreen } from './data/hook';
 import NotificationTabs from './NotificationTabs';
 import messages from './messages';
 import NotificationTour from './tours/NotificationTour';
+import NotificationContext from './context';
 
 const Notifications = () => {
   const intl = useIntl();
@@ -244,7 +246,9 @@ const Notifications = () => {
                 </Popover.Title>
               </div>
               <Popover.Content className="notification-content p-0">
-                <NotificationTabs popoverHeaderRef={headerRef} notificationRef={popoverRef} />
+                <NotificationContext.Provider value={{ popoverHeaderRef: headerRef, notificationRef: popoverRef }}>
+                  <NotificationTabs />
+                </NotificationContext.Provider>
               </Popover.Content>
               {getConfig().NOTIFICATION_FEEDBACK_URL && (
                 <Button
@@ -263,7 +267,7 @@ const Notifications = () => {
         <div ref={buttonRef}>
           <IconButton
             isActive={enableNotificationTray}
-            alt="notification bell icon"
+            alt={intl.formatMessage(messages.notificationBellIconAltMessage)}
             onClick={toggleNotificationTray}
             src={NotificationsNone}
             iconAs={Icon}

--- a/src/Notifications/messages.js
+++ b/src/Notifications/messages.js
@@ -46,6 +46,16 @@ const messages = defineMessages({
     defaultMessage: 'Notifications are automatically cleared after {days} days',
     description: 'Message showing that expired notifications will be deleted',
   },
+  noNotificationsYetMessage: {
+    id: 'notification.no.message',
+    defaultMessage: 'No notifications yet',
+    description: 'Message visible when there is no notification in the notification tray',
+  },
+  noNotificationHelpMessage: {
+    id: 'notification.no.help.message',
+    defaultMessage: 'When you receive notifications they’ll show up here',
+    description: 'Message showing that when you receive notifications they’ll show up here',
+  },
 });
 
 export default messages;

--- a/src/Notifications/messages.js
+++ b/src/Notifications/messages.js
@@ -56,6 +56,11 @@ const messages = defineMessages({
     defaultMessage: 'When you receive notifications they’ll show up here',
     description: 'Message showing that when you receive notifications they’ll show up here',
   },
+  notificationBellIconAltMessage: {
+    id: 'notification.bell.icon.alt.message',
+    defaultMessage: 'Notification bell icon',
+    description: 'Alt message for notification bell icon',
+  },
 });
 
 export default messages;

--- a/src/Notifications/notificationTabs.test.jsx
+++ b/src/Notifications/notificationTabs.test.jsx
@@ -72,20 +72,4 @@ describe('Notification Tabs test cases.', () => {
 
     expect(within(tabs[0]).queryByRole('status')).toBeInTheDocument();
   });
-
-  it('Successfully selected reminder tab.', async () => {
-    renderComponent();
-
-    const bellIcon = screen.queryByTestId('notification-bell-icon');
-    await act(async () => { fireEvent.click(bellIcon); });
-    const notificationTab = screen.getAllByRole('tab');
-
-    await act(async () => { fireEvent.click(notificationTab[0], { dataset: { rbEventKey: 'reminders' } }); });
-
-    const tabs = screen.queryAllByRole('tab');
-    const selectedTab = tabs.find(tab => tab.getAttribute('aria-selected') === 'true');
-
-    expect(within(selectedTab).queryByText('reminders')).toBeInTheDocument();
-    expect(within(selectedTab).queryByRole('status')).not.toBeInTheDocument();
-  });
 });

--- a/src/Notifications/notificationTabs.test.jsx
+++ b/src/Notifications/notificationTabs.test.jsx
@@ -72,4 +72,20 @@ describe('Notification Tabs test cases.', () => {
 
     expect(within(tabs[0]).queryByRole('status')).toBeInTheDocument();
   });
+
+  it('Successfully selected reminder tab.', async () => {
+    renderComponent();
+
+    const bellIcon = screen.queryByTestId('notification-bell-icon');
+    await act(async () => { fireEvent.click(bellIcon); });
+    const notificationTab = screen.getAllByRole('tab');
+    let selectedTab = screen.queryByTestId('notification-tab-reminders');
+
+    expect(selectedTab).not.toHaveClass('active');
+
+    await act(async () => { fireEvent.click(notificationTab[0], { dataset: { rbEventKey: 'reminders' } }); });
+    selectedTab = screen.queryByTestId('notification-tab-reminders');
+
+    expect(selectedTab).toHaveClass('active');
+  });
 });

--- a/src/index.scss
+++ b/src/index.scss
@@ -210,6 +210,16 @@ $white: #fff;
   }
 }
 
+.notification-lg-bell-icon {
+  width: 56px !important;
+  height: 56px !important;
+
+  span:first-child {
+    width: 32px !important;
+    height: 32px !important;
+  }
+}
+
 .notification-button.btn-icon-light-active {
     background-color: #F2F0EF !important;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -354,3 +354,7 @@ $white: #fff;
 .popover-margin-top {
   margin-top: -68px !important;
 }
+
+.height-inherit {
+  height: inherit;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -358,3 +358,11 @@ $white: #fff;
 .height-inherit {
   height: inherit;
 }
+
+.height-100vh {
+  height: 100vh
+}
+
+.height-91vh {
+  height: 91vh
+}


### PR DESCRIPTION
[INF-1082](https://2u-internal.atlassian.net/browse/INF-1082)

**Description**

1. "No notification yet" message should be visible in the notification tray when there is no notification for the user.
    Figma: [Notifications](https://www.figma.com/file/1WsIDaf9Alfy2r8eNYj6vX/Notifications?type=design&node-id=678-15078&mode=design)
2. Added test case "Successfully showed No notification yet message when the notification tray is empty".

**Screenshots**
**Before**
![Screenshot 2023-10-13 at 5 21 55 PM](https://github.com/edx/frontend-component-header-edx/assets/72802712/8cd8b93b-e0be-4c4a-bae9-92c99ace550e)

**After**
![image](https://github.com/edx/frontend-component-header-edx/assets/72802712/d08d431e-85d3-4ee1-84ff-a3f074f62dfb)
