### PR TITLE
fix: fixed issue of badge aligment on safari

### DIFF
--- a/src/Notifications/notification.scss
+++ b/src/Notifications/notification.scss
@@ -114,8 +114,14 @@
   background: var(--text-on-light-brand-500, #D23228) !important;
   line-height: 20px !important;
   padding: 4px !important;
-  padding-left: 3px !important;
+  padding-left: 4px !important;
   margin-left: -21px;
+}
+
+@supports (-webkit-backdrop-filter: blur(1px)) {
+  .notification-badge {
+    margin-left: -17px;
+  }
 }
 
 .notification-end-title {


### PR DESCRIPTION
[INF-1152](https://2u-internal.atlassian.net/browse/INF-1152)

**Description**
Alignment of notification badge is out on safari browser.


**Before**
![image](https://github.com/edx/frontend-component-header-edx/assets/72802712/659547b0-0db7-4abe-bd72-fff825cb6ad7)

**After**
<img width="257" alt="Screenshot 2023-11-02 at 11 40 18 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/c67a734f-095f-4110-b7a5-7559cb9df6a1">

