### PR TITLE
fix: fixed bell icon alignment for empty section

### DIFF
--- a/src/Notifications/NotificationEmptySection.jsx
+++ b/src/Notifications/NotificationEmptySection.jsx
@@ -25,7 +25,7 @@ const EmptyNotifications = () => {
         variant="light"
         id="bell-icon"
         iconClassNames="text-primary-500"
-        className="ml-4 mr-1 notification-button notification-lg-bell-icon"
+        className="ml-4 mr-1 notification-button notification-lg-bell-icon pl-2"
         data-testid="notification-bell-icon"
       />
       <div className="mx-auto mt-3.5 mb-3 font-size-22 notification-end-title line-height-24">


### PR DESCRIPTION
[INF-1163](https://2u-internal.atlassian.net/browse/INF-1163)

**Description**
---
Fixed bell icon alignment for notification empty section.

**Screenshots**
---
**Before**

<img width="96" alt="Screenshot 2023-12-11 at 2 56 41 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/e83a39b6-dfe3-4c31-bb00-aa6ac06c209e">

----

**After**

<img width="124" alt="Screenshot 2023-12-11 at 2 55 57 PM" src="https://github.com/edx/frontend-component-header-edx/assets/72802712/eab51249-2457-4994-91a6-e8b8352127ff">
