### PR TITLE
feat: bumped frontend-platform to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-semantically-released",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "4.0.4",
+        "@edx/frontend-enterprise-utils": "4.0.5",
         "@edx/paragon": "21.5.6",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
@@ -33,7 +33,7 @@
         "@edx/brand": "npm:@edx/brand-edx.org@2.1.2",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-build": "13.0.14",
-        "@edx/frontend-platform": "5.6.1",
+        "@edx/frontend-platform": "6.2.0",
         "@edx/reactifex": "2.2.0",
         "@testing-library/dom": "9.3.3",
         "@testing-library/jest-dom": "5.17.0",
@@ -52,7 +52,7 @@
         "redux-saga": "1.3.0"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^4.0.0 || ^5.0.0",
+        "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"
@@ -3083,15 +3083,15 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-utils": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-4.0.4.tgz",
-      "integrity": "sha512-BsjSGfYuN97ZPR45vJ+dNuhEk4EBH65qLTyVrfyv/G+hYOYPvNpx9wSDUnxhdEt60ECVorkgnXj17VHB7spCvQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-4.0.5.tgz",
+      "integrity": "sha512-SmeHVm1iF24zCG6F2f1unyQlFWHnj+lwlJY6nhMMcsobdZ1LvGH/D+tFgAYnyg69/U/5zj1XVENVrJ90dYPkHw==",
       "dependencies": {
         "@testing-library/react": "12.1.4",
         "history": "4.10.1"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^5.0.0",
+        "@edx/frontend-platform": "^5.0.0 || ^6.0.0",
         "react": "^16.12.0 || ^17.0.0",
         "react-dom": "^16.12.0 || ^17.0.0",
         "react-router-dom": "^6.0.0"
@@ -3133,9 +3133,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.6.1.tgz",
-      "integrity": "sha512-7MOIjGGYplVY7yHrSea90EkQ24UxKxRKU9FaihB41yUSL/Vin1txDuIn3059Xr+60QfIKRsym+LogXe9IZ47Dw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-6.2.0.tgz",
+      "integrity": "sha512-hsyrxDsYlFgoHO6G7MKKvYanySnH8pXjxgsLHVvBMK3oD/PvyNqWn5y2Nhb3MlsSEvHD/UQkycOlDxUWWsLzuA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -3154,7 +3154,7 @@
         "lodash.merge": "4.6.2",
         "lodash.snakecase": "4.1.1",
         "pubsub-js": "1.9.4",
-        "react-intl": "^5.25.0",
+        "react-intl": "6.5.5",
         "universal-cookie": "4.0.4"
       },
       "bin": {
@@ -3167,9 +3167,146 @@
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",
-        "react-redux": "^7.1.1",
+        "react-redux": "^7.1.1 || ^8.1.1",
         "react-router-dom": "^6.0.0",
         "redux": "^4.0.4"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.0.tgz",
+      "integrity": "sha512-PEVLoa3zBevWSCZzPIM/lvPCi8P5l4G+NXQMc/CjEiaCWgyHieUoo0nM7Bs0n/NbuQ6JpXEolivQ9pKSBHaDlA==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.5.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.3.tgz",
+      "integrity": "sha512-X/jy10V9S/vW+qlplqhMUxR8wErQ0mmIYSq4mrjpjDl9mbuGcCILcI1SUYkL5nlM4PJqpc0KOS0bFkkJNPxYRw==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/icu-skeleton-parser": "1.7.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.7.0.tgz",
+      "integrity": "sha512-Cfdo/fgbZzpN/jlN/ptQVe0lRHora+8ezrEeg2RfrNjyp+YStwBy7cqDY8k5/z2LzXg6O0AdzAV91XS0zIWv+A==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/intl": {
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.9.9.tgz",
+      "integrity": "sha512-JI3CNgL2Zdg5lv9ncT2sYKqbAj2RGrCbdzaCckIxMPxn4QuHuOVvYUGmBAXVusBmfG/0sxLmMrnwnBioz+QKdA==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "@formatjs/intl-displaynames": "6.6.4",
+        "@formatjs/intl-listformat": "7.5.3",
+        "intl-messageformat": "10.5.8",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "typescript": "5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/intl-displaynames": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.4.tgz",
+      "integrity": "sha512-ET8KQ+L9Q0K8x1SnJQa4DNssUcbATlMopWqYvGGR8yAvw5qwAQc1fv+DshCoZNIE9pbcue0IGC4kWNAkWqlFag==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/intl-localematcher": "0.5.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/intl-listformat": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.5.3.tgz",
+      "integrity": "sha512-l7EOr0Yh1m8KagytukB90yw81uyzrM7amKFrgxXqphz4KeSIL0KPa68lPsdtZ+JmQB73GaDQRwLOwUKFZ1VZPQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/intl-localematcher": "0.5.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.2.tgz",
+      "integrity": "sha512-txaaE2fiBMagLrR4jYhxzFO6wEdEG4TPMqrzBAcbr4HFUYzH/YC+lg6OIzKCHm8WgDdyQevxbAAV1OgcXctuGw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/intl-messageformat": {
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.8.tgz",
+      "integrity": "sha512-NRf0jpBWV0vd671G5b06wNofAN8tp7WWDogMZyaU8GUAsmbouyvgwmFJI7zLjfAMpm3zK+vSwRP3jzaoIcMbaA==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/react-intl": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.5.5.tgz",
+      "integrity": "sha512-cI5UKvBh4tc1zxLIziHBYGMX3dhYWDEFlvUDVN6NfT2i96zTXz/zH2AmM8+2waqgOhwkFUzd+7kK1G9q7fiC2g==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "@formatjs/intl": "2.9.9",
+        "@formatjs/intl-displaynames": "6.6.4",
+        "@formatjs/intl-listformat": "7.5.3",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "16 || 17 || 18",
+        "hoist-non-react-statics": "^3.3.2",
+        "intl-messageformat": "10.5.8",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || 17 || 18",
+        "typescript": "5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@edx/frontend-platform/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@edx/new-relic-source-map-webpack-plugin": {
@@ -3440,6 +3577,7 @@
     "node_modules/@formatjs/fast-memoize": {
       "version": "1.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3447,6 +3585,7 @@
     "node_modules/@formatjs/icu-messageformat-parser": {
       "version": "2.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/icu-skeleton-parser": "1.3.6",
@@ -3456,6 +3595,7 @@
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.3.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "tslib": "^2.1.0"
@@ -3464,6 +3604,7 @@
     "node_modules/@formatjs/intl": {
       "version": "2.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/fast-memoize": "1.2.1",
@@ -3485,6 +3626,7 @@
     "node_modules/@formatjs/intl-displaynames": {
       "version": "5.4.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/intl-localematcher": "0.2.25",
@@ -3494,6 +3636,7 @@
     "node_modules/@formatjs/intl-listformat": {
       "version": "6.5.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/intl-localematcher": "0.2.25",
@@ -11643,6 +11786,7 @@
     "node_modules/intl-messageformat": {
       "version": "9.13.0",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/fast-memoize": "1.2.1",
@@ -18236,6 +18380,7 @@
     "node_modules/react-intl": {
       "version": "5.25.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/icu-messageformat-parser": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@edx/brand-edx.org@2.1.2",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-build": "13.0.14",
-    "@edx/frontend-platform": "5.6.1",
+    "@edx/frontend-platform": "6.2.0",
     "@edx/reactifex": "2.2.0",
     "@testing-library/dom": "9.3.3",
     "@testing-library/jest-dom": "5.17.0",
@@ -55,7 +55,7 @@
     "redux-saga": "1.3.0"
   },
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "4.0.4",
+    "@edx/frontend-enterprise-utils": "4.0.5",
     "@edx/paragon": "21.5.6",
     "@fortawesome/fontawesome-svg-core": "6.5.1",
     "@fortawesome/free-brands-svg-icons": "6.5.1",
@@ -76,7 +76,7 @@
     "timeago.js": "4.0.2"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^4.0.0 || ^5.0.0",
+    "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0"


### PR DESCRIPTION
## Description
Bumped frontend-platform to v6 which includes major version upgrades bumping `paragon` to `v21`, `react-redux` to `v8.1.1` & `react-intl` to `v6.4.7`