### PR TITLE
feat: remove username from header

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -26,6 +26,7 @@ subscribe(APP_READY, () => {
         authenticatedUser: {
           userId: '123abc',
           username: 'testuser',
+          name: 'test user',
           roles: [],
           administrator: false,
         },
@@ -37,6 +38,7 @@ subscribe(APP_READY, () => {
       <AppContext.Provider value={{
         authenticatedUser: {
           userId: '123abc',
+          name: 'test name',
           username: 'testuser',
           roles: [],
           administrator: false,

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -59,8 +59,11 @@ class DesktopHeader extends React.Component {
       userMenu,
       avatar,
       username,
+      name,
       intl,
     } = this.props;
+    const hideUsername = getConfig().HIDE_USERNAME_FROM_HEADER;
+    const usernameOrName = hideUsername ? name : username;
 
     return (
       <Dropdown>
@@ -69,10 +72,10 @@ class DesktopHeader extends React.Component {
           as={AvatarButton}
           src={avatar}
           alt=""
-          aria-label={intl.formatMessage(messages['header.label.account.menu.for'], { username })}
+          aria-label={intl.formatMessage(messages['header.label.account.menu.for'], { username: usernameOrName })}
           data-hj-suppress
         >
-          {username}
+          {!hideUsername && username}
         </Dropdown.Toggle>
 
         <Dropdown.Menu alignRight>
@@ -156,6 +159,7 @@ DesktopHeader.propTypes = {
   logoDestination: PropTypes.string,
   avatar: PropTypes.string,
   username: PropTypes.string,
+  name: PropTypes.string,
   loggedIn: PropTypes.bool,
 
   // i18n
@@ -171,6 +175,7 @@ DesktopHeader.defaultProps = {
   logoDestination: null,
   avatar: null,
   username: null,
+  name: '',
   loggedIn: false,
 };
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -32,6 +32,9 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     MINIMAL_HEADER: !!process.env.MINIMAL_HEADER,
     ENTERPRISE_LEARNER_PORTAL_HOSTNAME: process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME,
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
+    // this flag is introduced to unblock for new release.
+    // the flag would be removed in follow up PR
+    HIDE_USERNAME_FROM_HEADER: !!process.env.HIDE_USERNAME_FROM_HEADER,
   }, 'Header additional config');
 });
 
@@ -155,6 +158,7 @@ const Header = ({ intl }) => {
     logoDestination: getConfig().MINIMAL_HEADER ? null : `${config.LMS_BASE_URL}/dashboard`,
     loggedIn: authenticatedUser !== null,
     username: authenticatedUser !== null ? authenticatedUser.username : null,
+    name: authenticatedUser !== null ? authenticatedUser.name : null,
     avatar: authenticatedUser !== null ? authenticatedUser.avatar : null,
     mainMenu: getConfig().MINIMAL_HEADER || getConfig().AUTHN_MINIMAL_HEADER ? [] : mainMenu,
     userMenu: getConfig().AUTHN_MINIMAL_HEADER ? [] : userMenu,

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -74,6 +74,7 @@ describe('<Header />', () => {
       authenticatedUser: {
         userId: 'abc123',
         username: 'edX',
+        name: 'edX',
         roles: [],
         administrator: false,
       },

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -7,14 +7,20 @@ import { faUserCircle } from '@fortawesome/free-solid-svg-icons';
 
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Dropdown, Badge } from '@openedx/paragon';
+import { Avatar, Dropdown, Badge } from '@openedx/paragon';
 
 import messages from './messages';
 import Notifications from '../Notifications';
 import { selectShowNotificationTray } from '../Notifications/data/selectors';
 import { fetchAppsNotificationCount } from '../Notifications/data/thunks';
 
-const AuthenticatedUserDropdown = ({ enterpriseLearnerPortalLink, intl, username }) => {
+const AuthenticatedUserDropdown = (props) => {
+  const {
+    intl,
+    enterpriseLearnerPortalLink,
+    username,
+    name,
+  } = props;
   const dispatch = useDispatch();
   const showNotificationsTray = useSelector(selectShowNotificationTray);
 
@@ -47,17 +53,25 @@ const AuthenticatedUserDropdown = ({ enterpriseLearnerPortalLink, intl, username
     careersMenuItem = '';
   }
 
+  const dropdownToggle = (
+    <Dropdown.Toggle variant="outline-primary" id="user-dropdown">
+      <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
+      {getConfig().HIDE_USERNAME_FROM_HEADER ? (
+        <Avatar size="sm" alt={name} className="mr-2" />
+      ) : (
+        <span data-hj-suppress className="d-none d-md-inline" data-testid="username">
+          {username}
+        </span>
+      )}
+    </Dropdown.Toggle>
+  );
+
   return (
     <>
       <a className="text-gray-700" href={`${getConfig().SUPPORT_URL}`}>{intl.formatMessage(messages.help)}</a>
       {showNotificationsTray && <Notifications />}
       <Dropdown className="user-dropdown ml-3">
-        <Dropdown.Toggle variant="outline-primary" id="user-dropdown">
-          <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
-          <span data-hj-suppress className="d-none d-md-inline">
-            {username}
-          </span>
-        </Dropdown.Toggle>
+        {dropdownToggle}
         <Dropdown.Menu className="dropdown-menu-right zIndex-2">
           {dashboardMenuItem}
           {careersMenuItem}
@@ -89,10 +103,12 @@ AuthenticatedUserDropdown.propTypes = {
   enterpriseLearnerPortalLink: PropTypes.string,
   intl: intlShape.isRequired,
   username: PropTypes.string.isRequired,
+  name: PropTypes.string,
 };
 
 AuthenticatedUserDropdown.defaultProps = {
   enterpriseLearnerPortalLink: '',
+  name: '',
 };
 
 export default injectIntl(AuthenticatedUserDropdown);

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -23,6 +23,7 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
   mergeConfig({
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL || '',
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL || '',
+    HIDE_USERNAME_FROM_HEADER: !!process.env.HIDE_USERNAME_FROM_HEADER,
   }, 'Learning Header additional config');
 });
 
@@ -92,6 +93,7 @@ const LearningHeader = ({
           <AuthenticatedUserDropdown
             enterpriseLearnerPortalLink={enterpriseLearnerPortalLink}
             username={authenticatedUser.username}
+            name={authenticatedUser.name}
           />
           )}
           {showUserDropdown && !authenticatedUser && (

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getConfig, mergeConfig } from '@edx/frontend-platform';
 import {
   authenticatedUser, initializeMockApp, render, screen,
 } from '../setupTest';
@@ -13,6 +14,17 @@ describe('Header', () => {
   it('displays user button', () => {
     render(<Header />);
     expect(screen.getByText(authenticatedUser.username)).toBeInTheDocument();
+  });
+
+  it('displays user button without username', () => {
+    const config = getConfig();
+    mergeConfig({
+      ...config,
+      HIDE_USERNAME_FROM_HEADER: true,
+    });
+    const { queryByTestId } = render(<Header />);
+    const username = queryByTestId('username');
+    expect(username).not.toBeInTheDocument();
   });
 
   it('displays course data', () => {

--- a/src/studio-header/HeaderBody.jsx
+++ b/src/studio-header/HeaderBody.jsx
@@ -21,6 +21,7 @@ const HeaderBody = ({
   org,
   title,
   username,
+  name,
   isAdmin,
   studioBaseUrl,
   logoutUrl,
@@ -100,6 +101,7 @@ const HeaderBody = ({
           <UserMenu
             {...{
               username,
+              name,
               studioBaseUrl,
               logoutUrl,
               authenticatedUserAvatar,
@@ -125,6 +127,7 @@ HeaderBody.propTypes = {
   logoAltText: PropTypes.string,
   authenticatedUserAvatar: PropTypes.string,
   username: PropTypes.string,
+  name: PropTypes.string,
   isAdmin: PropTypes.bool,
   isMobile: PropTypes.bool,
   isHiddenMainMenu: PropTypes.bool,
@@ -150,6 +153,7 @@ HeaderBody.defaultProps = {
   title: '',
   authenticatedUserAvatar: null,
   username: null,
+  name: '',
   isAdmin: false,
   isMobile: false,
   isHiddenMainMenu: false,

--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -26,6 +26,7 @@ const StudioHeader = ({
     org,
     title,
     username: authenticatedUser?.username,
+    name: authenticatedUser?.name,
     isAdmin: authenticatedUser?.administrator,
     authenticatedUserAvatar: authenticatedUser?.avatar,
     studioBaseUrl: config.STUDIO_BASE_URL,

--- a/src/studio-header/StudioHeader.test.jsx
+++ b/src/studio-header/StudioHeader.test.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useMemo } from 'react';
+import { getConfig, mergeConfig } from '@edx/frontend-platform';
 import {
   render,
   fireEvent,
@@ -16,6 +17,7 @@ import messages from './messages';
 const authenticatedUser = {
   userId: 3,
   username: 'abc123',
+  name: 'test',
   administrator: true,
   roles: [],
   avatar: '/imges/test.png',
@@ -126,6 +128,17 @@ describe('Header', () => {
       const avatarIcon = getByTestId('avatar-icon');
 
       expect(avatarIcon).toBeVisible();
+    });
+
+    it('user menu should not contain username', async () => {
+      const config = getConfig();
+      mergeConfig({
+        ...config,
+        HIDE_USERNAME_FROM_HEADER: true,
+      });
+      const { container } = render(<RootWrapper {...props} />);
+      const userMenu = container.querySelector('#user-dropdown-menu');
+      expect(userMenu.textContent).toContain('');
     });
 
     it('should hide nav items if prop isHiddenMainMenu true', async () => {

--- a/src/studio-header/UserMenu.jsx
+++ b/src/studio-header/UserMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
 import {
   Avatar,
 } from '@openedx/paragon';
@@ -8,6 +9,7 @@ import NavDropdownMenu from './NavDropdownMenu';
 import getUserMenuItems from './utils';
 
 const UserMenu = ({
+  name,
   username,
   studioBaseUrl,
   logoutUrl,
@@ -17,22 +19,25 @@ const UserMenu = ({
   // injected
   intl,
 }) => {
+  const hideUsername = getConfig().HIDE_USERNAME_FROM_HEADER;
+  const avatarAlt = hideUsername ? name : username;
   const avatar = authenticatedUserAvatar ? (
     <img
       className="d-block w-100 h-100"
       src={authenticatedUserAvatar}
-      alt={username}
+      alt={avatarAlt}
       data-testid="avatar-image"
     />
   ) : (
     <Avatar
       size="sm"
       className="mr-2"
-      alt={username}
+      alt={avatarAlt}
       data-testid="avatar-icon"
     />
   );
-  const title = isMobile ? avatar : <>{avatar}{username}</>;
+
+  const title = (isMobile || hideUsername) ? avatar : <>{avatar}{username}</>;
 
   return (
     <NavDropdownMenu
@@ -50,6 +55,7 @@ const UserMenu = ({
 
 UserMenu.propTypes = {
   username: PropTypes.string,
+  name: PropTypes.string,
   studioBaseUrl: PropTypes.string.isRequired,
   logoutUrl: PropTypes.string.isRequired,
   authenticatedUserAvatar: PropTypes.string,
@@ -64,6 +70,7 @@ UserMenu.defaultProps = {
   isAdmin: false,
   authenticatedUserAvatar: null,
   username: null,
+  name: '',
 };
 
 export default injectIntl(UserMenu);


### PR DESCRIPTION
In the spirit of making registration experience quick and easy (more details on [MVP scope doc](https://2u-internal.atlassian.net/wiki/spaces/Ecomm/pages/653164545/Registration+Login+Progressive+Profiling+Profile+Account+Management+MVP#MVP-Scope-Estimate)), we want to be able to remove username from the registration form. This creates the need to remove it everywhere on the UX too. As part of this initiative, we will be removing username from the headers and making the dropdown consistent with [edx.org](http://edx.org/) site.

**Changes**
Set the flag `HIDE_USERNAME_FROM_HEADER` to hide the username from the header and replace the username with the name for the screen reader text when the flag is enabled.
The flag will be removed when this [PR](https://github.com/openedx/frontend-component-header/pull/465) would be merged

**Screenshots**
<table>
<tr>
<th>Component</th>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>Header</td>
<td>
<img width="146" alt="Screenshot 2024-02-13 at 1 31 38 PM" src="https://github.com/edx/frontend-component-header-edx/assets/78487564/03202009-df8b-4b52-9c38-86c919db0f79">
</td>
<td>
<img width="112" alt="Screenshot 2024-02-13 at 1 32 45 PM" src="https://github.com/edx/frontend-component-header-edx/assets/78487564/cc7efd7b-249b-4436-82ee-c216da9fe5b9">
</td>
</tr>
<tr>
<td>Studio Header</td>
<td>
<img width="135" alt="Screenshot 2024-02-13 at 1 36 17 PM" src="https://github.com/edx/frontend-component-header-edx/assets/78487564/b061cded-3892-4fc5-b698-cce2367e9442">
</td>
<td>
<img width="108" alt="Screenshot 2024-02-13 at 1 35 17 PM" src="https://github.com/edx/frontend-component-header-edx/assets/78487564/b538f291-d9c5-4c07-9138-6d5f39e59ed9">
</td>
</tr>
<tr>
<td>Learning Header</td>
<td>
<img width="173" alt="Screenshot 2024-02-13 at 1 38 22 PM" src="https://github.com/edx/frontend-component-header-edx/assets/78487564/f3e03724-0f6a-4fbc-ae20-e71e8da5899a">
</td>
<td>
<img width="183" alt="Screenshot 2024-02-13 at 1 39 38 PM" src="https://github.com/edx/frontend-component-header-edx/assets/78487564/80e8bd0a-b3ab-4655-ae12-ebcc7cc52da6">
</td>
</tr>
</table>

**Ticket**
[VAN-1804](https://2u-internal.atlassian.net/browse/VAN-1804)