### PR TITLE
feat: added notification tray for common header/learner dashboard

### DIFF
--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -197,7 +197,7 @@ class DesktopHeader extends React.Component {
                 ? (
                   <>
                     {this.renderSecondaryMenu()}
-                    {showNotificationsTray && <Notifications showLeftMargin={false} />}
+                    {showNotificationsTray && <Notifications />}
                     {this.renderUserMenu()}
                   </>
                 ) : this.renderLoggedOutItems()}

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import { AvatarButton, Dropdown } from '@openedx/paragon';
@@ -10,6 +12,9 @@ import UserMenuGroupSlot from './plugin-slots/UserMenuGroupSlot';
 import UserMenuItem from './common/UserMenuItem';
 import { Menu, MenuTrigger, MenuContent } from './Menu';
 import { LinkedLogo, Logo } from './Logo';
+import Notifications from './Notifications';
+import { selectShowNotificationTray } from './Notifications/data/selectors';
+import { fetchAppsNotificationCount } from './Notifications/data/thunks';
 
 // i18n
 import messages from './Header.messages';
@@ -20,6 +25,20 @@ import { CaretIcon } from './Icons';
 class DesktopHeader extends React.Component {
   constructor(props) { // eslint-disable-line no-useless-constructor
     super(props);
+    this.state = {
+      locationHref: window.location.href,
+    };
+  }
+
+  componentDidMount() {
+    this.props.fetchAppsNotificationCount();
+  }
+
+  componentDidUpdate() {
+    if (window.location.href !== this.state.locationHref) {
+      this.setState({ locationHref: window.location.href });
+      this.props.fetchAppsNotificationCount();
+    }
   }
 
   renderMenu(menu) {
@@ -152,6 +171,7 @@ class DesktopHeader extends React.Component {
       logoAltText,
       logoDestination,
       loggedIn,
+      showNotificationsTray,
       intl,
     } = this.props;
     const logoProps = { src: logo, alt: logoAltText, href: logoDestination };
@@ -177,6 +197,7 @@ class DesktopHeader extends React.Component {
                 ? (
                   <>
                     {this.renderSecondaryMenu()}
+                    {showNotificationsTray && <Notifications showLeftMargin={false} />}
                     {this.renderUserMenu()}
                   </>
                 ) : this.renderLoggedOutItems()}
@@ -220,7 +241,8 @@ DesktopHeader.propTypes = {
   name: PropTypes.string,
   email: PropTypes.string,
   loggedIn: PropTypes.bool,
-
+  showNotificationsTray: PropTypes.bool,
+  fetchAppsNotificationCount: PropTypes.func.isRequired,
   // i18n
   intl: intlShape.isRequired,
 };
@@ -237,6 +259,15 @@ DesktopHeader.defaultProps = {
   name: '',
   email: '',
   loggedIn: false,
+  showNotificationsTray: false,
 };
 
-export default injectIntl(DesktopHeader);
+const mapDispatchToProps = (dispatch) => ({
+  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
+});
+
+const mapStateToProps = (state) => ({
+  showNotificationsTray: selectShowNotificationTray(state),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(DesktopHeader));

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -13,7 +13,7 @@ import UserMenuItem from './common/UserMenuItem';
 import { Menu, MenuTrigger, MenuContent } from './Menu';
 import { LinkedLogo, Logo } from './Logo';
 import Notifications from './Notifications';
-import { mapDispatchToProps, mapStateToProps } from './Notifications/data/selectors';
+import { mapDispatchToProps, mapStateToProps } from './data/selectors';
 
 // i18n
 import messages from './Header.messages';

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -13,8 +13,7 @@ import UserMenuItem from './common/UserMenuItem';
 import { Menu, MenuTrigger, MenuContent } from './Menu';
 import { LinkedLogo, Logo } from './Logo';
 import Notifications from './Notifications';
-import { selectShowNotificationTray } from './Notifications/data/selectors';
-import { fetchAppsNotificationCount } from './Notifications/data/thunks';
+import { mapDispatchToProps, mapStateToProps } from './Notifications/data/selectors';
 
 // i18n
 import messages from './Header.messages';
@@ -261,13 +260,5 @@ DesktopHeader.defaultProps = {
   loggedIn: false,
   showNotificationsTray: false,
 };
-
-const mapDispatchToProps = (dispatch) => ({
-  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
-});
-
-const mapStateToProps = (state) => ({
-  showNotificationsTray: selectShowNotificationTray(state),
-});
 
 export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(DesktopHeader));

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -197,7 +197,7 @@ class DesktopHeader extends React.Component {
                 ? (
                   <>
                     {this.renderSecondaryMenu()}
-                    {showNotificationsTray && <Notifications />}
+                    {showNotificationsTray && <Notifications showLeftMargin={false} />}
                     {this.renderUserMenu()}
                   </>
                 ) : this.renderLoggedOutItems()}

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import Responsive from 'react-responsive';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { AppContext } from '@edx/frontend-platform/react';
+import { AppContext, AppProvider } from '@edx/frontend-platform/react';
 import { Badge } from '@openedx/paragon';
 import {
   APP_CONFIG_INITIALIZED,
@@ -16,6 +16,7 @@ import { useEnterpriseConfig } from '@edx/frontend-enterprise-utils';
 import PropTypes from 'prop-types';
 import DesktopHeader from './DesktopHeader';
 import MobileHeader from './MobileHeader';
+import store from './store';
 
 import messages from './Header.messages';
 
@@ -26,6 +27,8 @@ ensureConfig([
   'MARKETING_SITE_BASE_URL',
   'ORDER_HISTORY_URL',
   'LOGO_URL',
+  'ACCOUNT_SETTINGS_URL',
+  'NOTIFICATION_FEEDBACK_URL',
 ], 'Header component');
 
 subscribe(APP_CONFIG_INITIALIZED, () => {
@@ -33,6 +36,8 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     MINIMAL_HEADER: !!process.env.MINIMAL_HEADER,
     ENTERPRISE_LEARNER_PORTAL_HOSTNAME: process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME,
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
+    ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL || '',
+    NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL || '',
   }, 'Header additional config');
 });
 
@@ -194,14 +199,14 @@ const Header = ({
   }
 
   return (
-    <>
+    <AppProvider store={store} wrapWithRouter={false}>
       <Responsive maxWidth={769}>
         <MobileHeader {...props} />
       </Responsive>
       <Responsive minWidth={769}>
         <DesktopHeader {...props} />
       </Responsive>
-    </>
+    </AppProvider>
   );
 };
 

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -7,8 +7,9 @@ import { useEnterpriseConfig } from '@edx/frontend-enterprise-utils';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
 import { Context as ResponsiveContext } from 'react-responsive';
-
 import { fireEvent, render, screen } from '@testing-library/react';
+
+import { initializeMockApp } from './setupTest';
 import Header from './index';
 
 jest.mock('@edx/frontend-platform');
@@ -40,6 +41,10 @@ const HeaderContext = ({ width, contextValue }) => (
 describe('<Header />', () => {
   beforeEach(() => {
     useEnterpriseConfig.mockReturnValue({});
+  });
+  beforeAll(async () => {
+    // We need to mock AuthService to implicitly use `getAuthenticatedUser` within `AppContext.Provider`.
+    await initializeMockApp();
   });
 
   const mockUseEnterpriseConfig = () => {

--- a/src/MobileHeader.jsx
+++ b/src/MobileHeader.jsx
@@ -13,8 +13,7 @@ import { Menu, MenuTrigger, MenuContent } from './Menu';
 import { LinkedLogo, Logo } from './Logo';
 import UserMenuItem from './common/UserMenuItem';
 import Notifications from './Notifications';
-import { selectShowNotificationTray } from './Notifications/data/selectors';
-import { fetchAppsNotificationCount } from './Notifications/data/thunks';
+import { mapDispatchToProps, mapStateToProps } from './Notifications/data/selectors';
 // i18n
 import messages from './Header.messages';
 
@@ -268,13 +267,5 @@ MobileHeader.defaultProps = {
   stickyOnMobile: true,
   showNotificationsTray: false,
 };
-
-const mapDispatchToProps = (dispatch) => ({
-  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
-});
-
-const mapStateToProps = (state) => ({
-  showNotificationsTray: selectShowNotificationTray(state),
-});
 
 export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(MobileHeader));

--- a/src/MobileHeader.jsx
+++ b/src/MobileHeader.jsx
@@ -13,7 +13,7 @@ import { Menu, MenuTrigger, MenuContent } from './Menu';
 import { LinkedLogo, Logo } from './Logo';
 import UserMenuItem from './common/UserMenuItem';
 import Notifications from './Notifications';
-import { mapDispatchToProps, mapStateToProps } from './Notifications/data/selectors';
+import { mapDispatchToProps, mapStateToProps } from './data/selectors';
 // i18n
 import messages from './Header.messages';
 

--- a/src/MobileHeader.jsx
+++ b/src/MobileHeader.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
+import { AvatarButton } from '@openedx/paragon';
 
 // Local Components
-import { AvatarButton } from '@openedx/paragon';
 import UserMenuGroupSlot from './plugin-slots/UserMenuGroupSlot';
 import UserMenuGroupItemSlot from './plugin-slots/UserMenuGroupItemSlot';
 import { Menu, MenuTrigger, MenuContent } from './Menu';
 import { LinkedLogo, Logo } from './Logo';
 import UserMenuItem from './common/UserMenuItem';
-
+import Notifications from './Notifications';
+import { selectShowNotificationTray } from './Notifications/data/selectors';
+import { fetchAppsNotificationCount } from './Notifications/data/thunks';
 // i18n
 import messages from './Header.messages';
 
@@ -20,6 +24,20 @@ import { MenuIcon } from './Icons';
 class MobileHeader extends React.Component {
   constructor(props) { // eslint-disable-line no-useless-constructor
     super(props);
+    this.state = {
+      locationHref: window.location.href,
+    };
+  }
+
+  componentDidMount() {
+    this.props.fetchAppsNotificationCount();
+  }
+
+  componentDidUpdate() {
+    if (window.location.href !== this.state.locationHref) {
+      this.setState({ locationHref: window.location.href });
+      this.props.fetchAppsNotificationCount();
+    }
   }
 
   renderMenu(menu) {
@@ -135,6 +153,7 @@ class MobileHeader extends React.Component {
       mainMenu,
       userMenu,
       loggedOutItems,
+      showNotificationsTray,
     } = this.props;
     const logoProps = { src: logo, alt: logoAltText, href: logoDestination };
     const stickyClassName = stickyOnMobile ? 'sticky-top' : '';
@@ -173,6 +192,7 @@ class MobileHeader extends React.Component {
         </div>
         {userMenu.length > 0 || loggedOutItems.length > 0 ? (
           <div className="w-100 d-flex justify-content-end align-items-center">
+            {showNotificationsTray && loggedIn && <Notifications />}
             <Menu tag="nav" aria-label={intl.formatMessage(messages['header.label.secondary.nav'])} className="position-static">
               <MenuTrigger
                 tag={AvatarButton}
@@ -227,7 +247,8 @@ MobileHeader.propTypes = {
   email: PropTypes.string,
   loggedIn: PropTypes.bool,
   stickyOnMobile: PropTypes.bool,
-
+  showNotificationsTray: PropTypes.bool,
+  fetchAppsNotificationCount: PropTypes.func.isRequired,
   // i18n
   intl: intlShape.isRequired,
 };
@@ -245,7 +266,15 @@ MobileHeader.defaultProps = {
   email: '',
   loggedIn: false,
   stickyOnMobile: true,
-
+  showNotificationsTray: false,
 };
 
-export default injectIntl(MobileHeader);
+const mapDispatchToProps = (dispatch) => ({
+  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
+});
+
+const mapStateToProps = (state) => ({
+  showNotificationsTray: selectShowNotificationTray(state),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(MobileHeader));

--- a/src/Notifications/data/selectors.js
+++ b/src/Notifications/data/selectors.js
@@ -1,7 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
 
-import { fetchAppsNotificationCount } from './thunks';
-
 export const selectNotificationStatus = state => state.notifications.notificationStatus;
 
 export const selectNotificationListStatus = state => state.notifications.notificationListStatus;

--- a/src/Notifications/data/selectors.js
+++ b/src/Notifications/data/selectors.js
@@ -1,5 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 
+import { fetchAppsNotificationCount } from './thunks';
+
 export const selectNotificationStatus = state => state.notifications.notificationStatus;
 
 export const selectNotificationListStatus = state => state.notifications.notificationListStatus;
@@ -27,3 +29,11 @@ export const selectPaginationData = state => state.notifications.pagination;
 export const selectTrayOpened = state => state.notifications.trayOpened;
 
 export const selectExpiryDays = state => state.notifications.notificationExpiryDays;
+
+export const mapDispatchToProps = (dispatch) => ({
+  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
+});
+
+export const mapStateToProps = (state) => ({
+  showNotificationsTray: selectShowNotificationTray(state),
+});

--- a/src/Notifications/data/selectors.js
+++ b/src/Notifications/data/selectors.js
@@ -29,11 +29,3 @@ export const selectPaginationData = state => state.notifications.pagination;
 export const selectTrayOpened = state => state.notifications.trayOpened;
 
 export const selectExpiryDays = state => state.notifications.notificationExpiryDays;
-
-export const mapDispatchToProps = (dispatch) => ({
-  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
-});
-
-export const mapStateToProps = (state) => ({
-  showNotificationsTray: selectShowNotificationTray(state),
-});

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -6,6 +6,7 @@ import React, {
 
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -26,7 +27,7 @@ import NotificationTabs from './NotificationTabs';
 
 import './notification.scss';
 
-const Notifications = () => {
+const Notifications = ({ showLeftMargin }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const popoverRef = useRef(null);
@@ -144,7 +145,9 @@ const Notifications = () => {
             iconAs={Icon}
             variant="light"
             iconClassNames="text-primary-500"
-            className="ml-4 mr-1 notification-button"
+            className={classNames('mr-1 notification-button', {
+              'ml-4': showLeftMargin,
+            })}
             data-testid="notification-bell-icon"
           />
           {notificationCounts?.count > 0 && (
@@ -166,6 +169,14 @@ const Notifications = () => {
       <NotificationTour />
     </>
   );
+};
+
+Notifications.propTypes = {
+  showLeftMargin: PropTypes.bool,
+};
+
+Notifications.defaultProps = {
+  showLeftMargin: true,
 };
 
 export default Notifications;

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -6,6 +6,7 @@ import React, {
 
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -26,7 +27,7 @@ import NotificationTabs from './NotificationTabs';
 
 import './notification.scss';
 
-const Notifications = () => {
+const Notifications = ({ showLeftMargin }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const popoverRef = useRef(null);
@@ -144,7 +145,9 @@ const Notifications = () => {
             iconAs={Icon}
             variant="light"
             iconClassNames="text-primary-500"
-            className="mr-1 notification-button"
+            className={classNames('mr-1 notification-button', {
+              'ml-4': showLeftMargin,
+            })}
             data-testid="notification-bell-icon"
           />
           {notificationCounts?.count > 0 && (
@@ -166,6 +169,14 @@ const Notifications = () => {
       <NotificationTour />
     </>
   );
+};
+
+Notifications.propTypes = {
+  showLeftMargin: PropTypes.bool,
+};
+
+Notifications.defaultProps = {
+  showLeftMargin: true,
 };
 
 export default Notifications;

--- a/src/Notifications/index.jsx
+++ b/src/Notifications/index.jsx
@@ -6,7 +6,6 @@ import React, {
 
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -27,7 +26,7 @@ import NotificationTabs from './NotificationTabs';
 
 import './notification.scss';
 
-const Notifications = ({ showLeftMargin }) => {
+const Notifications = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const popoverRef = useRef(null);
@@ -145,9 +144,7 @@ const Notifications = ({ showLeftMargin }) => {
             iconAs={Icon}
             variant="light"
             iconClassNames="text-primary-500"
-            className={classNames('mr-1 notification-button', {
-              'ml-4': showLeftMargin,
-            })}
+            className="mr-1 notification-button"
             data-testid="notification-bell-icon"
           />
           {notificationCounts?.count > 0 && (
@@ -169,14 +166,6 @@ const Notifications = ({ showLeftMargin }) => {
       <NotificationTour />
     </>
   );
-};
-
-Notifications.propTypes = {
-  showLeftMargin: PropTypes.bool,
-};
-
-Notifications.defaultProps = {
-  showLeftMargin: true,
 };
 
 export default Notifications;

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -1,328 +1,285 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Header /> minimal renders correctly for authenticated users when minimal 1`] = `
-<header
-  className="site-header-desktop"
+<div
+  data-testid="redux-provider"
 >
-  <a
-    className="nav-skip sr-only sr-only-focusable"
-    href="#main"
+  <header
+    className="site-header-desktop"
   >
-    Skip to main content
-  </a>
-  <div
-    className="container-fluid null"
-  >
-    <div
-      className="nav-container position-relative d-flex align-items-center"
+    <a
+      className="nav-skip sr-only sr-only-focusable"
+      href="#main"
     >
-      <img
-        alt="edX"
-        className="logo"
-        src="https://edx-cdn.org/v3/prod/logo.svg"
-      />
-      <nav
-        aria-label="Main"
-        className="nav main-nav"
-      />
-      <nav
-        aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+      Skip to main content
+    </a>
+    <div
+      className="container-fluid null"
+    >
+      <div
+        className="nav-container position-relative d-flex align-items-center"
       >
-        <div
-          className="pgn__dropdown pgn__dropdown-light dropdown"
-          data-testid="dropdown"
+        <img
+          alt="edX"
+          className="logo"
+          src="https://edx-cdn.org/v3/prod/logo.svg"
+        />
+        <nav
+          aria-label="Main"
+          className="nav main-nav"
+        />
+        <nav
+          aria-label="Secondary"
+          className="nav secondary-menu-container align-items-center ml-auto"
         >
-          <button
-            alt=""
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-label="Account menu for edX Test"
-            className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
-            data-hj-suppress={true}
-            disabled={false}
-            id="menu-dropdown"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="pgn__dropdown pgn__dropdown-light dropdown"
+            data-testid="dropdown"
           >
-            <img
+            <button
               alt=""
-              className="pgn__avatar pgn__avatar-sm"
-              src="icon/mock/path"
-            />
-          </button>
-        </div>
-      </nav>
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Account menu for edX Test"
+              className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
+              data-hj-suppress={true}
+              disabled={false}
+              id="menu-dropdown"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                className="pgn__avatar pgn__avatar-sm"
+                src="icon/mock/path"
+              />
+            </button>
+          </div>
+        </nav>
+      </div>
     </div>
-  </div>
-</header>
+  </header>
+</div>
 `;
 
 exports[`<Header /> minimal renders correctly for unauthenticated users when minimal 1`] = `
-<header
-  className="site-header-desktop"
+<div
+  data-testid="redux-provider"
 >
-  <a
-    className="nav-skip sr-only sr-only-focusable"
-    href="#main"
+  <header
+    className="site-header-desktop"
   >
-    Skip to main content
-  </a>
-  <div
-    className="container-fluid null"
-  >
-    <div
-      className="nav-container position-relative d-flex align-items-center"
+    <a
+      className="nav-skip sr-only sr-only-focusable"
+      href="#main"
     >
-      <img
-        alt="edX"
-        className="logo"
-        src="https://edx-cdn.org/v3/prod/logo.svg"
-      />
-      <nav
-        aria-label="Main"
-        className="nav main-nav"
-      />
-      <nav
-        aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+      Skip to main content
+    </a>
+    <div
+      className="container-fluid null"
+    >
+      <div
+        className="nav-container position-relative d-flex align-items-center"
       >
-        <a
-          className="btn mr-2 btn-link"
-          href="http://localhost:18000/login"
+        <img
+          alt="edX"
+          className="logo"
+          src="https://edx-cdn.org/v3/prod/logo.svg"
+        />
+        <nav
+          aria-label="Main"
+          className="nav main-nav"
+        />
+        <nav
+          aria-label="Secondary"
+          className="nav secondary-menu-container align-items-center ml-auto"
         >
-          Login
-        </a>
-        <a
-          className="btn mr-2 btn-outline-primary"
-          href="http://localhost:18000/register"
-        >
-          Sign Up
-        </a>
-      </nav>
+          <a
+            className="btn mr-2 btn-link"
+            href="http://localhost:18000/login"
+          >
+            Login
+          </a>
+          <a
+            className="btn mr-2 btn-outline-primary"
+            href="http://localhost:18000/register"
+          >
+            Sign Up
+          </a>
+        </nav>
+      </div>
     </div>
-  </div>
-</header>
+  </header>
+</div>
 `;
 
 exports[`<Header /> renders correctly for authenticated users on desktop 1`] = `
-<header
-  className="site-header-desktop"
+<div
+  data-testid="redux-provider"
 >
-  <a
-    className="nav-skip sr-only sr-only-focusable"
-    href="#main"
+  <header
+    className="site-header-desktop"
   >
-    Skip to main content
-  </a>
-  <div
-    className="container-fluid null"
-  >
-    <div
-      className="nav-container position-relative d-flex align-items-center"
+    <a
+      className="nav-skip sr-only sr-only-focusable"
+      href="#main"
     >
-      <a
-        className="logo"
-        href="http://localhost:18000/dashboard"
-      >
-        <img
-          alt="edX"
-          className="d-block"
-          src="https://edx-cdn.org/v3/prod/logo.svg"
-        />
-      </a>
-      <nav
-        aria-label="Main"
-        className="nav main-nav"
+      Skip to main content
+    </a>
+    <div
+      className="container-fluid null"
+    >
+      <div
+        className="nav-container position-relative d-flex align-items-center"
       >
         <a
-          className="nav-link"
+          className="logo"
           href="http://localhost:18000/dashboard"
-          onClick={null}
         >
-          Courses
+          <img
+            alt="edX"
+            className="d-block"
+            src="https://edx-cdn.org/v3/prod/logo.svg"
+          />
         </a>
-        <a
-          className="nav-link"
-          href="http://localhost:18000/dashboard/programs"
-          onClick={null}
+        <nav
+          aria-label="Main"
+          className="nav main-nav"
         >
-          Programs
-        </a>
-        <a
-          className="nav-link"
-          href="http://localhost:18000/course"
-          onClick={[Function]}
-        >
-          Discover New
-        </a>
-      </nav>
-      <nav
-        aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
-      >
-        <div
-          className="pgn__dropdown pgn__dropdown-light dropdown"
-          data-testid="dropdown"
-        >
-          <button
-            alt=""
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-label="Account menu for edX"
-            className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
-            data-hj-suppress={true}
-            disabled={false}
-            id="menu-dropdown"
-            onClick={[Function]}
-            type="button"
+          <a
+            className="nav-link"
+            href="http://localhost:18000/dashboard"
+            onClick={null}
           >
-            <img
+            Courses
+          </a>
+          <a
+            className="nav-link"
+            href="http://localhost:18000/dashboard/programs"
+            onClick={null}
+          >
+            Programs
+          </a>
+          <a
+            className="nav-link"
+            href="http://localhost:18000/course"
+            onClick={[Function]}
+          >
+            Discover New
+          </a>
+        </nav>
+        <nav
+          aria-label="Secondary"
+          className="nav secondary-menu-container align-items-center ml-auto"
+        >
+          <div
+            className="pgn__dropdown pgn__dropdown-light dropdown"
+            data-testid="dropdown"
+          >
+            <button
               alt=""
-              className="pgn__avatar pgn__avatar-sm"
-              src="icon/mock/path"
-            />
-          </button>
-        </div>
-      </nav>
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Account menu for edX"
+              className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
+              data-hj-suppress={true}
+              disabled={false}
+              id="menu-dropdown"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                className="pgn__avatar pgn__avatar-sm"
+                src="icon/mock/path"
+              />
+            </button>
+          </div>
+        </nav>
+      </div>
     </div>
-  </div>
-</header>
+  </header>
+</div>
 `;
 
 exports[`<Header /> renders correctly for authenticated users on mobile 1`] = `
-<header
-  aria-label="Main"
-  className="site-header-mobile d-flex justify-content-between align-items-center shadow sticky-top"
+<div
+  data-testid="redux-provider"
 >
-  <a
-    className="nav-skip sr-only sr-only-focusable"
-    href="#main"
-  >
-    Skip to main content
-  </a>
-  <div
-    className="w-100 d-flex justify-content-start"
-  >
-    <div
-      className="menu position-static"
-      onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-    >
-      <button
-        aria-expanded={false}
-        aria-haspopup="menu"
-        aria-label="Main Menu"
-        className="menu-trigger icon-button"
-        onClick={[Function]}
-        title="Main Menu"
-      >
-        <svg
-          aria-hidden={true}
-          focusable="false"
-          height="24px"
-          role="img"
-          style={
-            {
-              "height": "1.5rem",
-              "width": "1.5rem",
-            }
-          }
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <rect
-            fill="currentColor"
-            height="2"
-            width="20"
-            x="2"
-            y="5"
-          />
-          <rect
-            fill="currentColor"
-            height="2"
-            width="20"
-            x="2"
-            y="11"
-          />
-          <rect
-            fill="currentColor"
-            height="2"
-            width="20"
-            x="2"
-            y="17"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div
-    className="w-100 d-flex justify-content-center"
+  <header
+    aria-label="Main"
+    className="site-header-mobile d-flex justify-content-between align-items-center shadow sticky-top"
   >
     <a
-      className="logo"
-      href="http://localhost:18000/dashboard"
-      itemType="http://schema.org/Organization"
+      className="nav-skip sr-only sr-only-focusable"
+      href="#main"
     >
-      <img
-        alt="edX"
-        className="d-block"
-        src="https://edx-cdn.org/v3/prod/logo.svg"
-      />
+      Skip to main content
     </a>
-  </div>
-  <div
-    className="w-100 d-flex justify-content-end align-items-center"
-  >
-    <nav
-      aria-label="Secondary"
-      className="menu position-static"
-      onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-    >
-      <button
-        aria-expanded={false}
-        aria-haspopup="menu"
-        aria-label="Account Menu"
-        className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md menu-trigger null pgn__avatar-button-hide-label btn btn-tertiary btn-md"
-        disabled={false}
-        onClick={[Function]}
-        title="Account Menu"
-        type="button"
-      >
-        <img
-          alt="edX Test"
-          className="pgn__avatar pgn__avatar-sm"
-          src="icon/mock/path"
-        />
-      </button>
-    </nav>
-  </div>
-</header>
-`;
-
-exports[`<Header /> renders correctly for unauthenticated users on desktop 1`] = `
-<header
-  className="site-header-desktop"
->
-  <a
-    className="nav-skip sr-only sr-only-focusable"
-    href="#main"
-  >
-    Skip to main content
-  </a>
-  <div
-    className="container-fluid null"
-  >
     <div
-      className="nav-container position-relative d-flex align-items-center"
+      className="w-100 d-flex justify-content-start"
+    >
+      <div
+        className="menu position-static"
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <button
+          aria-expanded={false}
+          aria-haspopup="menu"
+          aria-label="Main Menu"
+          className="menu-trigger icon-button"
+          onClick={[Function]}
+          title="Main Menu"
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height="24px"
+            role="img"
+            style={
+              {
+                "height": "1.5rem",
+                "width": "1.5rem",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 24 24"
+            width="24px"
+          >
+            <rect
+              fill="currentColor"
+              height="2"
+              width="20"
+              x="2"
+              y="5"
+            />
+            <rect
+              fill="currentColor"
+              height="2"
+              width="20"
+              x="2"
+              y="11"
+            />
+            <rect
+              fill="currentColor"
+              height="2"
+              width="20"
+              x="2"
+              y="17"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      className="w-100 d-flex justify-content-center"
     >
       <a
         className="logo"
         href="http://localhost:18000/dashboard"
+        itemType="http://schema.org/Organization"
       >
         <img
           alt="edX"
@@ -330,164 +287,231 @@ exports[`<Header /> renders correctly for unauthenticated users on desktop 1`] =
           src="https://edx-cdn.org/v3/prod/logo.svg"
         />
       </a>
-      <nav
-        aria-label="Main"
-        className="nav main-nav"
-      >
-        <a
-          className="nav-link"
-          href="http://localhost:18000/dashboard"
-          onClick={null}
-        >
-          Courses
-        </a>
-        <a
-          className="nav-link"
-          href="http://localhost:18000/dashboard/programs"
-          onClick={null}
-        >
-          Programs
-        </a>
-        <a
-          className="nav-link"
-          href="http://localhost:18000/course"
-          onClick={[Function]}
-        >
-          Discover New
-        </a>
-      </nav>
+    </div>
+    <div
+      className="w-100 d-flex justify-content-end align-items-center"
+    >
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="menu position-static"
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
       >
-        <a
-          className="btn mr-2 btn-link"
-          href="http://localhost:18000/login"
+        <button
+          aria-expanded={false}
+          aria-haspopup="menu"
+          aria-label="Account Menu"
+          className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md menu-trigger null pgn__avatar-button-hide-label btn btn-tertiary btn-md"
+          disabled={false}
+          onClick={[Function]}
+          title="Account Menu"
+          type="button"
         >
-          Login
-        </a>
-        <a
-          className="btn mr-2 btn-outline-primary"
-          href="http://localhost:18000/register"
-        >
-          Sign Up
-        </a>
+          <img
+            alt="edX Test"
+            className="pgn__avatar pgn__avatar-sm"
+            src="icon/mock/path"
+          />
+        </button>
       </nav>
     </div>
-  </div>
-</header>
+  </header>
+</div>
+`;
+
+exports[`<Header /> renders correctly for unauthenticated users on desktop 1`] = `
+<div
+  data-testid="redux-provider"
+>
+  <header
+    className="site-header-desktop"
+  >
+    <a
+      className="nav-skip sr-only sr-only-focusable"
+      href="#main"
+    >
+      Skip to main content
+    </a>
+    <div
+      className="container-fluid null"
+    >
+      <div
+        className="nav-container position-relative d-flex align-items-center"
+      >
+        <a
+          className="logo"
+          href="http://localhost:18000/dashboard"
+        >
+          <img
+            alt="edX"
+            className="d-block"
+            src="https://edx-cdn.org/v3/prod/logo.svg"
+          />
+        </a>
+        <nav
+          aria-label="Main"
+          className="nav main-nav"
+        >
+          <a
+            className="nav-link"
+            href="http://localhost:18000/dashboard"
+            onClick={null}
+          >
+            Courses
+          </a>
+          <a
+            className="nav-link"
+            href="http://localhost:18000/dashboard/programs"
+            onClick={null}
+          >
+            Programs
+          </a>
+          <a
+            className="nav-link"
+            href="http://localhost:18000/course"
+            onClick={[Function]}
+          >
+            Discover New
+          </a>
+        </nav>
+        <nav
+          aria-label="Secondary"
+          className="nav secondary-menu-container align-items-center ml-auto"
+        >
+          <a
+            className="btn mr-2 btn-link"
+            href="http://localhost:18000/login"
+          >
+            Login
+          </a>
+          <a
+            className="btn mr-2 btn-outline-primary"
+            href="http://localhost:18000/register"
+          >
+            Sign Up
+          </a>
+        </nav>
+      </div>
+    </div>
+  </header>
+</div>
 `;
 
 exports[`<Header /> renders correctly for unauthenticated users on mobile 1`] = `
-<header
-  aria-label="Main"
-  className="site-header-mobile d-flex justify-content-between align-items-center shadow sticky-top"
+<div
+  data-testid="redux-provider"
 >
-  <a
-    className="nav-skip sr-only sr-only-focusable"
-    href="#main"
-  >
-    Skip to main content
-  </a>
-  <div
-    className="w-100 d-flex justify-content-start"
-  >
-    <div
-      className="menu position-static"
-      onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-    >
-      <button
-        aria-expanded={false}
-        aria-haspopup="menu"
-        aria-label="Main Menu"
-        className="menu-trigger icon-button"
-        onClick={[Function]}
-        title="Main Menu"
-      >
-        <svg
-          aria-hidden={true}
-          focusable="false"
-          height="24px"
-          role="img"
-          style={
-            {
-              "height": "1.5rem",
-              "width": "1.5rem",
-            }
-          }
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <rect
-            fill="currentColor"
-            height="2"
-            width="20"
-            x="2"
-            y="5"
-          />
-          <rect
-            fill="currentColor"
-            height="2"
-            width="20"
-            x="2"
-            y="11"
-          />
-          <rect
-            fill="currentColor"
-            height="2"
-            width="20"
-            x="2"
-            y="17"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div
-    className="w-100 d-flex justify-content-center"
+  <header
+    aria-label="Main"
+    className="site-header-mobile d-flex justify-content-between align-items-center shadow sticky-top"
   >
     <a
-      className="logo"
-      href="http://localhost:18000/dashboard"
-      itemType="http://schema.org/Organization"
+      className="nav-skip sr-only sr-only-focusable"
+      href="#main"
     >
-      <img
-        alt="edX"
-        className="d-block"
-        src="https://edx-cdn.org/v3/prod/logo.svg"
-      />
+      Skip to main content
     </a>
-  </div>
-  <div
-    className="w-100 d-flex justify-content-end align-items-center"
-  >
-    <nav
-      aria-label="Secondary"
-      className="menu position-static"
-      onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
+    <div
+      className="w-100 d-flex justify-content-start"
     >
-      <button
-        aria-expanded={false}
-        aria-haspopup="menu"
-        aria-label="Account Menu"
-        className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md menu-trigger null pgn__avatar-button-hide-label btn btn-tertiary btn-md"
-        disabled={false}
-        onClick={[Function]}
-        title="Account Menu"
-        type="button"
+      <div
+        className="menu position-static"
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <button
+          aria-expanded={false}
+          aria-haspopup="menu"
+          aria-label="Main Menu"
+          className="menu-trigger icon-button"
+          onClick={[Function]}
+          title="Main Menu"
+        >
+          <svg
+            aria-hidden={true}
+            focusable="false"
+            height="24px"
+            role="img"
+            style={
+              {
+                "height": "1.5rem",
+                "width": "1.5rem",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 24 24"
+            width="24px"
+          >
+            <rect
+              fill="currentColor"
+              height="2"
+              width="20"
+              x="2"
+              y="5"
+            />
+            <rect
+              fill="currentColor"
+              height="2"
+              width="20"
+              x="2"
+              y="11"
+            />
+            <rect
+              fill="currentColor"
+              height="2"
+              width="20"
+              x="2"
+              y="17"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      className="w-100 d-flex justify-content-center"
+    >
+      <a
+        className="logo"
+        href="http://localhost:18000/dashboard"
+        itemType="http://schema.org/Organization"
       >
         <img
-          alt=""
-          className="pgn__avatar pgn__avatar-sm"
-          src="icon/mock/path"
+          alt="edX"
+          className="d-block"
+          src="https://edx-cdn.org/v3/prod/logo.svg"
         />
-      </button>
-    </nav>
-  </div>
-</header>
+      </a>
+    </div>
+    <div
+      className="w-100 d-flex justify-content-end align-items-center"
+    >
+      <nav
+        aria-label="Secondary"
+        className="menu position-static"
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <button
+          aria-expanded={false}
+          aria-haspopup="menu"
+          aria-label="Account Menu"
+          className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md menu-trigger null pgn__avatar-button-hide-label btn btn-tertiary btn-md"
+          disabled={false}
+          onClick={[Function]}
+          title="Account Menu"
+          type="button"
+        >
+          <img
+            alt=""
+            className="pgn__avatar pgn__avatar-sm"
+            src="icon/mock/path"
+          />
+        </button>
+      </nav>
+    </div>
+  </header>
+</div>
 `;

--- a/src/data/selectors.js
+++ b/src/data/selectors.js
@@ -1,0 +1,10 @@
+import { fetchAppsNotificationCount } from '../Notifications/data/thunks';
+import { selectShowNotificationTray } from '../Notifications/data/selectors';
+
+export const mapDispatchToProps = (dispatch) => ({
+  fetchAppsNotificationCount: () => dispatch(fetchAppsNotificationCount()),
+});
+
+export const mapStateToProps = (state) => ({
+  showNotificationsTray: selectShowNotificationTray(state),
+});


### PR DESCRIPTION
[INF-1508](https://2u-internal.atlassian.net/browse/INF-1508)

**Description**
We are integrating the notification tray into the common header for both desktop and mobile versions. This will allow all MFEs using this common header to include the notification icon in their headers.

**Screenshots**
<img width="1439" alt="Screenshot 2024-08-15 at 4 19 18 PM" src="https://github.com/user-attachments/assets/672646eb-14e2-4a11-b85d-ab4455119cb3">

<img width="1436" alt="Screenshot 2024-08-15 at 4 19 05 PM" src="https://github.com/user-attachments/assets/d54af362-c78e-4550-ab7b-b78185e2fd0b">

<img width="421" alt="Screenshot 2024-08-15 at 4 36 23 PM" src="https://github.com/user-attachments/assets/31627526-bdb8-44c1-8cdd-7bd940ef7b33">

<img width="414" alt="Screenshot 2024-08-15 at 4 36 37 PM" src="https://github.com/user-attachments/assets/a66c35fb-a259-4e11-8e6f-8e59c158c1d9">
