### PR TITLE
fix: updated notifications preferences url

### DIFF
--- a/src/Notification/index.jsx
+++ b/src/Notification/index.jsx
@@ -143,7 +143,7 @@ const Notifications = ({ notificationAppData, showLeftMargin }) => {
                 >
                   {intl.formatMessage(messages.notificationTitle)}
                   <Hyperlink
-                    destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+                    destination={`${getConfig().ACCOUNT_SETTINGS_URL}/#notifications`}
                     target="_blank"
                     showLaunchIcon={false}
                   >


### PR DESCRIPTION
Description
Updated the notifications preferences URL in the notification tray.

Old URL: https://account.edx.org/notifications
New URL: https://account.edx.org/#notifications