### PR TITLE
feat: update plugin slot ids

### DIFF
--- a/src/plugin-slots/NotificationsSlot/index.jsx
+++ b/src/plugin-slots/NotificationsSlot/index.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 const NotificationsSlot = () => (
-  <PluginSlot id="notifications_tray" />
+  <PluginSlot
+    id="org.edx.frontend.header.notifications_tray.v1"
+    idAliases={['notifications_tray']}
+  />
 );
 
 export default NotificationsSlot;

--- a/src/plugin-slots/UserMenuGroupItemSlot/index.jsx
+++ b/src/plugin-slots/UserMenuGroupItemSlot/index.jsx
@@ -4,7 +4,8 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 const UserMenuGroupItemSlot = () => (
   <PluginSlot
-    id="header_user_menu_group_item_slot"
+    id="org.edx.frontend.header.user_menu_group_item.v1"
+    idAliases={['header_user_menu_group_item_slot']}
   />
 );
 

--- a/src/plugin-slots/UserMenuGroupSlot/index.jsx
+++ b/src/plugin-slots/UserMenuGroupSlot/index.jsx
@@ -4,7 +4,8 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 const UserMenuGroupSlot = () => (
   <PluginSlot
-    id="header_user_menu_group_slot"
+    id="org.edx.frontend.header.user_menu_group.v1"
+    idAliases={['header_user_menu_group_slot']}
   />
 );
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { createConfig } = require('@openedx/frontend-build');
 
 module.exports = createConfig('webpack-dev', {
-  entry: path.resolve(__dirname, 'example'),
+  entry: {
+    app: path.resolve(__dirname, 'example'),
+  },
   output: {
     path: path.resolve(__dirname, 'example/dist'),
     publicPath: '/',


### PR DESCRIPTION
This adds a `idAliases` prop to each PluginSlot which holds the old ID in an array. The `id` prop has been set to an id that conforms to the ADR set in frontend-plugin-framework: https://github.com/openedx/frontend-plugin-framework/blob/master/docs/decisions/0003-slot-naming-and-life-cycle.rst

The old ID for each slot can still be used as long as the `idAliases` feature is available in FPF. The public, open-source MFEs have been updated already for this. Example PR in Learner Dashboard: https://github.com/openedx/frontend-app-learner-dashboard/pull/608

Additionally, the webpack.dev.config.js file has been modified slightly to allow for easier local development. This small change will enable developers to simply `npm start` and it will spin up the example app.