### PR TITLE
chore: migrate from @edx/frontend-enterprise-utils to @2uinc/frontend-enterprise-utils

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,15 @@
 const { createConfig } = require('@openedx/frontend-build');
 
-module.exports = createConfig('jest', {
+const config = createConfig('jest', {
   setupFilesAfterEnv: [
     '<rootDir>/src/setupTest.js',
   ],
 });
+
+// @openedx/frontend-build's default transformIgnorePatterns only covers @edx/ and @openedx/ scopes.
+// We must expand it to include @2uinc/ packages which also ship untranspiled ESM.
+config.transformIgnorePatterns = [
+  '/node_modules/(?!@(open)?edx|@2uinc)',
+];
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-semantically-released",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "10.0.0",
+        "@2uinc/frontend-enterprise-utils": "^10.0.2",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "^6.6.0",
         "@fortawesome/free-regular-svg-icons": "^6.6.0",
@@ -49,6 +49,22 @@
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-redux": "^7.2.9",
+        "react-router-dom": "^6.0.0"
+      }
+    },
+    "node_modules/@2uinc/frontend-enterprise-utils": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@2uinc/frontend-enterprise-utils/-/frontend-enterprise-utils-10.0.2.tgz",
+      "integrity": "sha512-J2aT8zdDaar4SxpYX/s+zWq79pYL72Wjp/JZvizrp9lrbozRZHV1QK3qK6fytaIw3ZYI4PmuFm3cciLnl7pNpA==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "history": "^4.10.1"
+      },
+      "peerDependencies": {
+        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
+        "@testing-library/react": ">11.0.0 <17.0.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.0.0"
       }
     },
@@ -2425,22 +2441,6 @@
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.18.0",
         "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-enterprise-utils": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-10.0.0.tgz",
-      "integrity": "sha512-MmvX8VvSQHYApjtsTpJlefv2uAqF1SCqR95hZVSqGMwccfKyWN8/GwftjTTXdUTTzsjp1nSh5P3ZX0jYJIm9XQ==",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "history": "^4.10.1"
-      },
-      "peerDependencies": {
-        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "@testing-library/react": ">11.0.0 <17.0.0",
-        "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.0.0"
       }
     },
     "node_modules/@edx/frontend-platform": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "10.0.0",
+    "@2uinc/frontend-enterprise-utils": "^10.0.2",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
     "@fortawesome/free-regular-svg-icons": "^6.6.0",

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": ["@edx", "@openedx"],
+      "matchPackagePatterns": ["@edx", "@openedx", "@2uinc"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -11,7 +11,7 @@ import {
   getConfig,
   subscribe,
 } from '@edx/frontend-platform';
-import { useEnterpriseConfig } from '@edx/frontend-enterprise-utils';
+import { useEnterpriseConfig } from '@2uinc/frontend-enterprise-utils';
 
 import PropTypes from 'prop-types';
 import DesktopHeader from './DesktopHeader';

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import TestRenderer from 'react-test-renderer';
-import { useEnterpriseConfig } from '@edx/frontend-enterprise-utils';
+import { useEnterpriseConfig } from '@2uinc/frontend-enterprise-utils';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
 import { Context as ResponsiveContext } from 'react-responsive';
@@ -14,7 +14,7 @@ import Header from './index';
 import { initializeMockApp } from './setupTest';
 
 jest.mock('@edx/frontend-platform');
-jest.mock('@edx/frontend-enterprise-utils');
+jest.mock('@2uinc/frontend-enterprise-utils');
 
 getConfig.mockReturnValue({});
 

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
-import { useEnterpriseConfig } from '@edx/frontend-enterprise-utils';
+import { useEnterpriseConfig } from '@2uinc/frontend-enterprise-utils';
 import {
   APP_CONFIG_INITIALIZED, getConfig, ensureConfig, subscribe, mergeConfig,
 } from '@edx/frontend-platform';


### PR DESCRIPTION
Replace the abandoned @edx/frontend-enterprise-utils dependency with @2uinc/frontend-enterprise-utils. Expand Jest transformIgnorePatterns to cover the @2uinc scope since @openedx/frontend-build only handles @edx and @openedx by default.