### PR TITLE
feat: add system-wide status alert to all headers

### DIFF
--- a/docs/using_custom_header.rst
+++ b/docs/using_custom_header.rst
@@ -115,7 +115,7 @@ Status Alert
 
 A site-wide status banner can be displayed above the header to surface maintenance notices or other operational messages. The same behavior is available in the ``Header``, ``StudioHeader``, and ``LearningHeader`` components.
 
-The banner is controlled by two runtime settings, each of which must be truthy for it to appear:
+These settings are supplied at runtime via the MFE config endpoint and can be set per-MFE or globally.
 
 ``STATUS_ALERT_ENABLED``
 ************************

--- a/docs/using_custom_header.rst
+++ b/docs/using_custom_header.rst
@@ -118,14 +118,14 @@ A site-wide status banner can be displayed above the header to surface maintenan
 - The banner cannot be dismissed.
 - The same behavior is available in the ``Header``, ``StudioHeader``, and ``LearningHeader`` components.
 
-The following settings are supplied at runtime via the MFE config endpoint, which allows it to be set globally or as a per-MFE override.
+The following settings are supplied at runtime via the MFE config api, which allows it to be set globally (using LMS setting ``MFE_CONFIG``) or as a per-MFE override (using LMS setting ``MFE_CONFIG_OVERRIDES``).
 
 ``STATUS_ALERT_ENABLED``
 ************************
 
-Runtime setting supplied via the MFE config endpoint. Set to ``true`` to activate the banner. Defaults to off when absent.
+Runtime setting supplied via the MFE config api. Set to ``true`` to activate the banner. Defaults to off when absent.
 
 ``STATUS_ALERT_MESSAGE``
 ************************
 
-Runtime setting supplied via the MFE config endpoint. The text shown in the banner. The banner is suppressed when this is empty or absent.
+Runtime setting supplied via the MFE config api. The text shown in the banner. The banner is suppressed when this is empty or absent.

--- a/docs/using_custom_header.rst
+++ b/docs/using_custom_header.rst
@@ -109,3 +109,20 @@ Some Important Notes
 - Intl formatted strings should be passed in content attribute.
 - Only menu items in the main menu can be disabled.
 - Menu items in the main menu and user menu can have ``isActive`` prop.
+
+Status Alert
+------------
+
+A site-wide status banner can be displayed above the header to surface maintenance notices or other operational messages. The same behavior is available in the ``Header``, ``StudioHeader``, and ``LearningHeader`` components.
+
+The banner is controlled by two runtime settings, each of which must be truthy for it to appear:
+
+``STATUS_ALERT_ENABLED``
+************************
+
+Runtime setting supplied via the MFE config endpoint. Set to ``true`` to activate the banner. Defaults to off when absent.
+
+``STATUS_ALERT_MESSAGE``
+************************
+
+Runtime setting supplied via the MFE config endpoint. The text shown in the banner. The banner is suppressed when this is empty or absent.

--- a/docs/using_custom_header.rst
+++ b/docs/using_custom_header.rst
@@ -113,9 +113,12 @@ Some Important Notes
 Status Alert
 ------------
 
-A site-wide status banner can be displayed above the header to surface maintenance notices or other operational messages. The same behavior is available in the ``Header``, ``StudioHeader``, and ``LearningHeader`` components.
+A site-wide status banner can be displayed above the header to surface maintenance notices or other operational messages.
 
-These settings are supplied at runtime via the MFE config endpoint and can be set per-MFE or globally.
+- The banner cannot be dismissed.
+- The same behavior is available in the ``Header``, ``StudioHeader``, and ``LearningHeader`` components.
+
+The following settings are supplied at runtime via the MFE config endpoint, which allows it to be set globally or as a per-MFE override.
 
 ``STATUS_ALERT_ENABLED``
 ************************

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -16,6 +16,7 @@ import { useEnterpriseConfig } from '@2uinc/frontend-enterprise-utils';
 import PropTypes from 'prop-types';
 import DesktopHeader from './DesktopHeader';
 import MobileHeader from './MobileHeader';
+import { StatusAlert } from './status-alert';
 
 import messages from './Header.messages';
 
@@ -38,6 +39,9 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL,
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL,
+    // Temporary per-MFE rollout toggle. The ENV_ prefix distinguishes the
+    // build-time env var from the runtime config setting STATUS_ALERT_ENABLED.
+    ENV_STATUS_ALERT_ENABLED: !!process.env.ENV_STATUS_ALERT_ENABLED,
   }, 'Header additional config');
 });
 
@@ -199,8 +203,14 @@ const Header = ({
     };
   }
 
+  const showStatusAlert = getConfig().ENV_STATUS_ALERT_ENABLED
+    && getConfig().STATUS_ALERT_ENABLED
+    && getConfig().STATUS_ALERT_MESSAGE;
+  const statusAlertMessage = getConfig().STATUS_ALERT_MESSAGE;
+
   return (
     <>
+      {showStatusAlert && <StatusAlert message={statusAlertMessage} />}
       <Responsive maxWidth={769}>
         <MobileHeader {...props} />
       </Responsive>

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -39,7 +39,6 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL,
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL,
-
   }, 'Header additional config');
 });
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -39,9 +39,7 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL,
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL,
-    // Temporary per-MFE rollout toggle. The ENV_ prefix distinguishes the
-    // build-time env var from the runtime config setting STATUS_ALERT_ENABLED.
-    ENV_STATUS_ALERT_ENABLED: !!process.env.ENV_STATUS_ALERT_ENABLED,
+
   }, 'Header additional config');
 });
 
@@ -203,8 +201,7 @@ const Header = ({
     };
   }
 
-  const showStatusAlert = getConfig().ENV_STATUS_ALERT_ENABLED
-    && getConfig().STATUS_ALERT_ENABLED
+  const showStatusAlert = getConfig().STATUS_ALERT_ENABLED
     && getConfig().STATUS_ALERT_MESSAGE;
   const statusAlertMessage = getConfig().STATUS_ALERT_MESSAGE;
 

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -229,4 +229,55 @@ describe('<Header />', () => {
       expect(wrapper.toJSON()).toMatchSnapshot();
     });
   });
+
+  describe('status alert', () => {
+    afterEach(() => {
+      getConfig.mockReturnValue({});
+    });
+
+    const STATUS_ALERT_MESSAGE = 'System maintenance in progress';
+    const contextValue = {
+      authenticatedUser: null,
+      config: APP_CONTEXT_CONFIG,
+    };
+
+    it('shows the banner when env toggle and runtime settings are all enabled', () => {
+      getConfig.mockReturnValue({
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE,
+      });
+      render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);
+      expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('hides the banner when env toggle is off', () => {
+      getConfig.mockReturnValue({
+        ENV_STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE,
+      });
+      render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);
+      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it('hides the banner when runtime config disables it', () => {
+      getConfig.mockReturnValue({
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_MESSAGE,
+      });
+      render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);
+      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it('hides the banner when the message is absent', () => {
+      getConfig.mockReturnValue({
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: true,
+      });
+      render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);
+      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -247,7 +247,7 @@ describe('<Header />', () => {
         STATUS_ALERT_MESSAGE,
       });
       render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);
-      expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeVisible();
     });
 
     it('hides the banner when runtime config disables it', () => {

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -241,9 +241,8 @@ describe('<Header />', () => {
       config: APP_CONTEXT_CONFIG,
     };
 
-    it('shows the banner when env toggle and runtime settings are all enabled', () => {
+    it('shows the banner when runtime settings are enabled', () => {
       getConfig.mockReturnValue({
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_MESSAGE,
       });
@@ -251,19 +250,8 @@ describe('<Header />', () => {
       expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeInTheDocument();
     });
 
-    it('hides the banner when env toggle is off', () => {
-      getConfig.mockReturnValue({
-        ENV_STATUS_ALERT_ENABLED: false,
-        STATUS_ALERT_ENABLED: true,
-        STATUS_ALERT_MESSAGE,
-      });
-      render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);
-      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
-    });
-
     it('hides the banner when runtime config disables it', () => {
       getConfig.mockReturnValue({
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: false,
         STATUS_ALERT_MESSAGE,
       });
@@ -273,7 +261,6 @@ describe('<Header />', () => {
 
     it('hides the banner when the message is absent', () => {
       getConfig.mockReturnValue({
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: true,
       });
       render(<HeaderContext width={{ width: 1280 }} contextValue={contextValue} />);

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -28,9 +28,7 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL || '',
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL || '',
     CAREERS_URL: process.env.CAREERS_URL || '',
-    // Temporary per-MFE rollout toggle. The ENV_ prefix distinguishes the
-    // build-time env var from the runtime config setting STATUS_ALERT_ENABLED.
-    ENV_STATUS_ALERT_ENABLED: !!process.env.ENV_STATUS_ALERT_ENABLED,
+
   }, 'Learning Header additional config');
 });
 
@@ -87,8 +85,7 @@ const LearningHeader = ({
     );
   }
 
-  const showStatusAlert = getConfig().ENV_STATUS_ALERT_ENABLED
-    && getConfig().STATUS_ALERT_ENABLED
+  const showStatusAlert = getConfig().STATUS_ALERT_ENABLED
     && getConfig().STATUS_ALERT_MESSAGE;
   const statusAlertMessage = getConfig().STATUS_ALERT_MESSAGE;
 

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -28,7 +28,6 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL || '',
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL || '',
     CAREERS_URL: process.env.CAREERS_URL || '',
-
   }, 'Learning Header additional config');
 });
 

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -14,6 +14,7 @@ import messages from './messages';
 import lightning from '../lightning';
 import AuthenticatedUser from './AuthenticatedUser';
 import { fetchUnifiedTranslationToggleEnabled } from './site-language/data';
+import { StatusAlert } from '../status-alert';
 
 ensureConfig([
   'ACCOUNT_SETTINGS_URL',
@@ -27,6 +28,9 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
     ACCOUNT_SETTINGS_URL: process.env.ACCOUNT_SETTINGS_URL || '',
     NOTIFICATION_FEEDBACK_URL: process.env.NOTIFICATION_FEEDBACK_URL || '',
     CAREERS_URL: process.env.CAREERS_URL || '',
+    // Temporary per-MFE rollout toggle. The ENV_ prefix distinguishes the
+    // build-time env var from the runtime config setting STATUS_ALERT_ENABLED.
+    ENV_STATUS_ALERT_ENABLED: !!process.env.ENV_STATUS_ALERT_ENABLED,
   }, 'Learning Header additional config');
 });
 
@@ -83,8 +87,14 @@ const LearningHeader = ({
     );
   }
 
+  const showStatusAlert = getConfig().ENV_STATUS_ALERT_ENABLED
+    && getConfig().STATUS_ALERT_ENABLED
+    && getConfig().STATUS_ALERT_MESSAGE;
+  const statusAlertMessage = getConfig().STATUS_ALERT_MESSAGE;
+
   return (
     <header className="learning-header">
+      {showStatusAlert && <StatusAlert message={statusAlertMessage} />}
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
       <div className="px-4 py-2.5 d-flex align-items-center learning-header-container">
         {headerLogo}

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -110,15 +110,13 @@ describe('Header', () => {
 
     afterEach(() => {
       mergeConfig({
-        ENV_STATUS_ALERT_ENABLED: false,
         STATUS_ALERT_ENABLED: false,
         STATUS_ALERT_MESSAGE: null,
       });
     });
 
-    it('shows the banner when env toggle and runtime settings are all enabled', () => {
+    it('shows the banner when runtime settings are enabled', () => {
       mergeConfig({
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_MESSAGE,
       });
@@ -126,19 +124,8 @@ describe('Header', () => {
       expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeInTheDocument();
     });
 
-    it('hides the banner when env toggle is off', () => {
-      mergeConfig({
-        ENV_STATUS_ALERT_ENABLED: false,
-        STATUS_ALERT_ENABLED: true,
-        STATUS_ALERT_MESSAGE,
-      });
-      render(<Header />);
-      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
-    });
-
     it('hides the banner when runtime config disables it', () => {
       mergeConfig({
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: false,
         STATUS_ALERT_MESSAGE,
       });
@@ -148,7 +135,6 @@ describe('Header', () => {
 
     it('hides the banner when the message is absent', () => {
       mergeConfig({
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_MESSAGE: null,
       });

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
+import { mergeConfig } from '@edx/frontend-platform';
 import {
   fireEvent, initializeMockApp, render, screen, waitFor,
 } from '../setupTest';
@@ -101,6 +102,58 @@ describe('Header', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('site-language-button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('status alert', () => {
+    const STATUS_ALERT_MESSAGE = 'System maintenance in progress';
+
+    afterEach(() => {
+      mergeConfig({
+        ENV_STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_MESSAGE: null,
+      });
+    });
+
+    it('shows the banner when env toggle and runtime settings are all enabled', () => {
+      mergeConfig({
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE,
+      });
+      render(<Header />);
+      expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('hides the banner when env toggle is off', () => {
+      mergeConfig({
+        ENV_STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE,
+      });
+      render(<Header />);
+      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it('hides the banner when runtime config disables it', () => {
+      mergeConfig({
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_MESSAGE,
+      });
+      render(<Header />);
+      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    it('hides the banner when the message is absent', () => {
+      mergeConfig({
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE: null,
+      });
+      render(<Header />);
+      expect(screen.queryByText(STATUS_ALERT_MESSAGE)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -121,7 +121,7 @@ describe('Header', () => {
         STATUS_ALERT_MESSAGE,
       });
       render(<Header />);
-      expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByText(STATUS_ALERT_MESSAGE)).toBeVisible();
     });
 
     it('hides the banner when runtime config disables it', () => {

--- a/src/status-alert/StatusAlert.jsx
+++ b/src/status-alert/StatusAlert.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PageBanner } from '@openedx/paragon';
+import { Icon, PageBanner } from '@openedx/paragon';
+import { WarningFilled } from '@openedx/paragon/icons';
 
 const StatusAlert = ({ message }) => (
-  <PageBanner variant="warning">{message}</PageBanner>
+  <PageBanner variant="warning">
+    <Icon src={WarningFilled} className="mie-2" />
+    {message}
+  </PageBanner>
 );
 
 StatusAlert.propTypes = {

--- a/src/status-alert/StatusAlert.jsx
+++ b/src/status-alert/StatusAlert.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { PageBanner } from '@openedx/paragon';
+
+const StatusAlert = ({ message }) => (
+  <PageBanner variant="warning">{message}</PageBanner>
+);
+
+StatusAlert.propTypes = {
+  message: PropTypes.string.isRequired,
+};
+
+export default StatusAlert;

--- a/src/status-alert/StatusAlert.test.jsx
+++ b/src/status-alert/StatusAlert.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '../setupTest';
+import { render, screen } from '@testing-library/react';
 
 import StatusAlert from './StatusAlert';
 

--- a/src/status-alert/StatusAlert.test.jsx
+++ b/src/status-alert/StatusAlert.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import StatusAlert from './StatusAlert';
+
+describe('StatusAlert', () => {
+  it('renders the message text', () => {
+    render(<StatusAlert message="System maintenance in progress" />);
+    expect(screen.getByText('System maintenance in progress')).toBeInTheDocument();
+  });
+});

--- a/src/status-alert/StatusAlert.test.jsx
+++ b/src/status-alert/StatusAlert.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '../setupTest';
 
 import StatusAlert from './StatusAlert';
 
 describe('StatusAlert', () => {
   it('renders the message text', () => {
     render(<StatusAlert message="System maintenance in progress" />);
-    expect(screen.getByText('System maintenance in progress')).toBeInTheDocument();
+    expect(screen.getByText('System maintenance in progress')).toBeVisible();
   });
 });

--- a/src/status-alert/StatusAlert.test.jsx
+++ b/src/status-alert/StatusAlert.test.jsx
@@ -8,4 +8,9 @@ describe('StatusAlert', () => {
     render(<StatusAlert message="System maintenance in progress" />);
     expect(screen.getByText('System maintenance in progress')).toBeVisible();
   });
+
+  it('renders the warning icon', () => {
+    const { container } = render(<StatusAlert message="System maintenance in progress" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
 });

--- a/src/status-alert/index.js
+++ b/src/status-alert/index.js
@@ -1,0 +1,1 @@
+export { default as StatusAlert } from './StatusAlert';

--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -2,10 +2,16 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Responsive from 'react-responsive';
 import { AppContext } from '@edx/frontend-platform/react';
-import { ensureConfig } from '@edx/frontend-platform';
+import {
+  APP_CONFIG_INITIALIZED,
+  ensureConfig,
+  mergeConfig,
+  subscribe,
+} from '@edx/frontend-platform';
 
 import MobileHeader from './MobileHeader';
 import HeaderBody from './HeaderBody';
+import { StatusAlert } from '../status-alert';
 
 ensureConfig([
   'STUDIO_BASE_URL',
@@ -14,6 +20,14 @@ ensureConfig([
   'LOGIN_URL',
   'LOGO_URL',
 ], 'Studio Header component');
+
+subscribe(APP_CONFIG_INITIALIZED, () => {
+  mergeConfig({
+    // Temporary per-MFE rollout toggle. The ENV_ prefix distinguishes the
+    // build-time env var from the runtime config setting STATUS_ALERT_ENABLED.
+    ENV_STATUS_ALERT_ENABLED: !!process.env.ENV_STATUS_ALERT_ENABLED,
+  }, 'Studio Header additional config');
+});
 
 const StudioHeader = ({
   number, org, title, isHiddenMainMenu, mainMenuDropdowns, outlineLink,
@@ -36,8 +50,14 @@ const StudioHeader = ({
     outlineLink,
   };
 
+  const showStatusAlert = config.ENV_STATUS_ALERT_ENABLED
+    && config.STATUS_ALERT_ENABLED
+    && config.STATUS_ALERT_MESSAGE;
+  const statusAlertMessage = config.STATUS_ALERT_MESSAGE;
+
   return (
     <div className="studio-header">
+      {showStatusAlert && <StatusAlert message={statusAlertMessage} />}
       <a className="nav-skip sr-only sr-only-focusable" href="#main">Skip to content</a>
       <Responsive maxWidth={841}>
         <MobileHeader {...props} />

--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -2,12 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Responsive from 'react-responsive';
 import { AppContext } from '@edx/frontend-platform/react';
-import {
-  APP_CONFIG_INITIALIZED,
-  ensureConfig,
-  mergeConfig,
-  subscribe,
-} from '@edx/frontend-platform';
+import { ensureConfig } from '@edx/frontend-platform';
 
 import MobileHeader from './MobileHeader';
 import HeaderBody from './HeaderBody';
@@ -21,13 +16,6 @@ ensureConfig([
   'LOGO_URL',
 ], 'Studio Header component');
 
-subscribe(APP_CONFIG_INITIALIZED, () => {
-  mergeConfig({
-    // Temporary per-MFE rollout toggle. The ENV_ prefix distinguishes the
-    // build-time env var from the runtime config setting STATUS_ALERT_ENABLED.
-    ENV_STATUS_ALERT_ENABLED: !!process.env.ENV_STATUS_ALERT_ENABLED,
-  }, 'Studio Header additional config');
-});
 
 const StudioHeader = ({
   number, org, title, isHiddenMainMenu, mainMenuDropdowns, outlineLink,
@@ -50,8 +38,7 @@ const StudioHeader = ({
     outlineLink,
   };
 
-  const showStatusAlert = config.ENV_STATUS_ALERT_ENABLED
-    && config.STATUS_ALERT_ENABLED
+  const showStatusAlert = config.STATUS_ALERT_ENABLED
     && config.STATUS_ALERT_MESSAGE;
   const statusAlertMessage = config.STATUS_ALERT_MESSAGE;
 

--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -16,7 +16,6 @@ ensureConfig([
   'LOGO_URL',
 ], 'Studio Header component');
 
-
 const StudioHeader = ({
   number, org, title, isHiddenMainMenu, mainMenuDropdowns, outlineLink,
 }) => {

--- a/src/studio-header/StudioHeader.test.jsx
+++ b/src/studio-header/StudioHeader.test.jsx
@@ -219,9 +219,8 @@ describe('Header', () => {
 
     beforeEach(() => { screenWidth = 1280; });
 
-    it('shows the banner when env toggle and runtime settings are all enabled', () => {
+    it('shows the banner when runtime settings are enabled', () => {
       extraConfig = {
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_MESSAGE,
       };
@@ -229,19 +228,8 @@ describe('Header', () => {
       expect(getByText(STATUS_ALERT_MESSAGE)).toBeVisible();
     });
 
-    it('hides the banner when env toggle is off', () => {
-      extraConfig = {
-        ENV_STATUS_ALERT_ENABLED: false,
-        STATUS_ALERT_ENABLED: true,
-        STATUS_ALERT_MESSAGE,
-      };
-      const { queryByText } = render(<RootWrapper {...props} />);
-      expect(queryByText(STATUS_ALERT_MESSAGE)).toBeNull();
-    });
-
     it('hides the banner when runtime config disables it', () => {
       extraConfig = {
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: false,
         STATUS_ALERT_MESSAGE,
       };
@@ -251,7 +239,6 @@ describe('Header', () => {
 
     it('hides the banner when the message is absent', () => {
       extraConfig = {
-        ENV_STATUS_ALERT_ENABLED: true,
         STATUS_ALERT_ENABLED: true,
       };
       const { queryByText } = render(<RootWrapper {...props} />);

--- a/src/studio-header/StudioHeader.test.jsx
+++ b/src/studio-header/StudioHeader.test.jsx
@@ -24,6 +24,7 @@ const authenticatedUser = {
 };
 let currentUser;
 let screenWidth = 1280;
+let extraConfig = {};
 
 const RootWrapper = ({
   ...props
@@ -36,6 +37,7 @@ const RootWrapper = ({
       SITE_NAME: process.env.SITE_NAME,
       STUDIO_BASE_URL: process.env.STUDIO_BASE_URL,
       LOGIN_URL: process.env.LOGIN_URL,
+      ...extraConfig,
     },
   }), []);
   const responsiveContextValue = useMemo(() => ({ width: screenWidth }), []);
@@ -77,6 +79,7 @@ describe('Header', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     currentUser = authenticatedUser;
+    extraConfig = {};
   });
   describe('desktop', () => {
     it('course lock up should be visible', () => {
@@ -208,6 +211,51 @@ describe('Header', () => {
       expect(mobileMenuButton).toBeNull();
 
       expect(desktopMenu).toBeNull();
+    });
+  });
+
+  describe('status alert', () => {
+    const STATUS_ALERT_MESSAGE = 'System maintenance in progress';
+
+    beforeEach(() => { screenWidth = 1280; });
+
+    it('shows the banner when env toggle and runtime settings are all enabled', () => {
+      extraConfig = {
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE,
+      };
+      const { getByText } = render(<RootWrapper {...props} />);
+      expect(getByText(STATUS_ALERT_MESSAGE)).toBeVisible();
+    });
+
+    it('hides the banner when env toggle is off', () => {
+      extraConfig = {
+        ENV_STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_MESSAGE,
+      };
+      const { queryByText } = render(<RootWrapper {...props} />);
+      expect(queryByText(STATUS_ALERT_MESSAGE)).toBeNull();
+    });
+
+    it('hides the banner when runtime config disables it', () => {
+      extraConfig = {
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: false,
+        STATUS_ALERT_MESSAGE,
+      };
+      const { queryByText } = render(<RootWrapper {...props} />);
+      expect(queryByText(STATUS_ALERT_MESSAGE)).toBeNull();
+    });
+
+    it('hides the banner when the message is absent', () => {
+      extraConfig = {
+        ENV_STATUS_ALERT_ENABLED: true,
+        STATUS_ALERT_ENABLED: true,
+      };
+      const { queryByText } = render(<RootWrapper {...props} />);
+      expect(queryByText(STATUS_ALERT_MESSAGE)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Overview

Adds a sitewide warning banner to Header, StudioHeader, and LearningHeader.

The banner is controlled by two runtime MFE config endpoint settings:
- `STATUS_ALERT_ENABLED`: runtime on/off from MFE config endpoint
- `STATUS_ALERT_MESSAGE`: runtime message text from MFE config endpoint

## Notes

- Uses Paragon `PageBanner` variant warning, which is not dismissable. 
- Runtime config is cached in browser in "Indexed DB" under `axios-cache` for 5 minutes.
- I used AI assistance for this PR.

## Testing

- This was tested locally in `frontend-app-learning` and `frontend-app-course-authoring` MFEs.
  - The plain Header (not LearningHeader or StudioHeader) was only tested via unit tests.  

Screenshot from local testing:
<img width="899" height="260" alt="Screenshot 2026-05-20 at 1 59 00 AM" src="https://github.com/user-attachments/assets/34f58cc7-dc8d-4428-860f-ec5eaf96e6a4" />

## Ticket

https://2u-internal.atlassian.net/browse/BOMS-562