### PR TITLE
fix: status banner bug in StudioHeader

### DIFF
--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -42,16 +42,18 @@ const StudioHeader = ({
   const statusAlertMessage = config.STATUS_ALERT_MESSAGE;
 
   return (
-    <div className="studio-header">
+    <>
       {showStatusAlert && <StatusAlert message={statusAlertMessage} />}
-      <a className="nav-skip sr-only sr-only-focusable" href="#main">Skip to content</a>
-      <Responsive maxWidth={841}>
-        <MobileHeader {...props} />
-      </Responsive>
-      <Responsive minWidth={842}>
-        <HeaderBody {...props} />
-      </Responsive>
-    </div>
+      <div className="studio-header">
+        <a className="nav-skip sr-only sr-only-focusable" href="#main">Skip to content</a>
+        <Responsive maxWidth={841}>
+          <MobileHeader {...props} />
+        </Responsive>
+        <Responsive minWidth={842}>
+          <HeaderBody {...props} />
+        </Responsive>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
The status banner was a part of the studio-header, rather than above it, which caused some style issues. The implementation now matches that of Header.

## Before:
<img width="899" height="260" alt="Screenshot 2026-05-20 at 1 59 00 AM" src="https://github.com/user-attachments/assets/feb9b3a0-0798-4a74-a65b-98bf7c24da67" />

## After:
<img width="1093" height="223" alt="Screenshot 2026-05-29 at 12 50 10 PM" src="https://github.com/user-attachments/assets/b40bc0b0-f45e-4df4-ae25-171cced67cb7" />