### PR TITLE
fix: prevent language switch race condition

### DIFF
--- a/src/learning-header/site-language/data.test.ts
+++ b/src/learning-header/site-language/data.test.ts
@@ -33,9 +33,17 @@ describe('site-language/data', () => {
   });
 
   describe('setSiteLanguage', () => {
-    it('calls patchPreferences and postSetLang', async () => {
-      mockPatchMethod.mockResolvedValueOnce({});
-      mockPostMethod.mockResolvedValueOnce({});
+    it('calls patchPreferences and postSetLang sequentially (patch first)', async () => {
+      const callOrder: string[] = [];
+
+      mockPatchMethod.mockImplementationOnce(() => {
+        callOrder.push('patch');
+        return Promise.resolve({});
+      });
+      mockPostMethod.mockImplementationOnce(() => {
+        callOrder.push('post');
+        return Promise.resolve({});
+      });
       await setSiteLanguage('fr', 'testuser');
       expect(mockPatchMethod).toHaveBeenCalledWith(
         'http://test/api/user/v1/preferences/testuser',
@@ -48,6 +56,7 @@ describe('site-language/data', () => {
         expect.objectContaining({ headers: expect.any(Object) }),
       );
       expect(mockPostMethod.mock.calls[0][1].get('language')).toBe('fr');
+      expect(callOrder).toEqual(['patch', 'post']);
     });
 
     it('encodes special characters in username', async () => {

--- a/src/learning-header/site-language/data.ts
+++ b/src/learning-header/site-language/data.ts
@@ -65,10 +65,8 @@ export async function setSiteLanguage(languageCode: string, username: string): P
 
   // Update the user's language preference by making API calls to the
   // user preferences API and the i18n API
-  await Promise.all([
-    patchPreferences(username, languageCode),
-    postSetLang(languageCode),
-  ]);
+  await patchPreferences(username, languageCode);
+  await postSetLang(languageCode);
 }
 
 /**


### PR DESCRIPTION
## Description
Fix intermittent language switch not persisting in the course learning header. When a learner changes the site language via the header language selector, the page sometimes reloads in the old language and requires 2–3 attempts to stick.

## Root Cause
`setSiteLanguage()` in `data.ts` fires `patchPreferences` (DB write) and `postSetLang` (cookie write) in parallel via `Promise.all`. Since `window.location.reload()` fires immediately after both resolve, the browser can reload before the `Set-Cookie` header from `postSetLang` is committed, causing the page to load with the stale language cookie.
On the 2nd/3rd attempt the cookie is already persisted from the previous call, which is why it appears to "eventually stick".

## Changes
- `src/learning-header/site-language/data.ts` — replaced `Promise.all([patchPreferences, postSetLang])` with sequential `await` calls: `patchPreferences` first, then `postSetLang`
- `src/learning-header/site-language/data.test.ts` — updated test to assert `patchPreferences` is called before `postSetLang`
